### PR TITLE
Reduce duplicated frontend spec setup

### DIFF
--- a/frontend/spec/client/GenericClient_spec.js
+++ b/frontend/spec/client/GenericClient_spec.js
@@ -1,7 +1,8 @@
 import GenericClient from '../../assets/js/client/GenericClient.js';
+import { preserveGlobals, stubFetchResponse } from '../support/factories.js';
 
 describe('GenericClient', function() {
-  let originalFetch;
+  let restoreGlobals;
 
   const buildResponseHeaders = (values = {}) => ({
     get(name) {
@@ -9,22 +10,23 @@ describe('GenericClient', function() {
     },
   });
 
+  const stubJsonResponse = (data, extra = {}) => stubFetchResponse({
+    ok: true,
+    json: () => Promise.resolve(data),
+    ...extra,
+  });
+
   beforeEach(function() {
-    originalFetch = global.fetch;
+    restoreGlobals = preserveGlobals('fetch');
   });
 
   afterEach(function() {
-    global.fetch = originalFetch;
+    restoreGlobals();
   });
 
   describe('#fetch', function() {
     it('returns parsed JSON body on success', async function() {
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ name: 'Item' }),
-        })
-      );
+      stubJsonResponse({ name: 'Item' });
 
       const client = new GenericClient(() => '');
       const result = await client.fetch('/items.json');
@@ -34,12 +36,7 @@ describe('GenericClient', function() {
     });
 
     it('appends hash query params to the URL', async function() {
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve([]),
-        })
-      );
+      stubJsonResponse([]);
 
       const client = new GenericClient(() => '#/items?page=3');
       await client.fetch('/items.json');
@@ -48,12 +45,7 @@ describe('GenericClient', function() {
     });
 
     it('does not append query string when hash has no params', async function() {
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve([]),
-        })
-      );
+      stubJsonResponse([]);
 
       const client = new GenericClient(() => '#/items');
       await client.fetch('/items.json');
@@ -62,9 +54,7 @@ describe('GenericClient', function() {
     });
 
     it('throws on non-ok response', async function() {
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({ ok: false, status: 500 })
-      );
+      stubFetchResponse({ ok: false, status: 500 });
 
       const client = new GenericClient(() => '');
 
@@ -76,13 +66,7 @@ describe('GenericClient', function() {
     it('returns data and pagination on success', async function() {
       const headers = buildResponseHeaders({ page: '2', pages: '9', per_page: '12' });
 
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({
-          ok: true,
-          headers,
-          json: () => Promise.resolve([{ id: 1 }]),
-        })
-      );
+      stubJsonResponse([{ id: 1 }], { headers });
 
       const client = new GenericClient(() => '');
       const result = await client.fetchIndex('/categories.json');
@@ -97,13 +81,7 @@ describe('GenericClient', function() {
     it('appends hash query params to the URL', async function() {
       const headers = buildResponseHeaders({ page: '1', pages: '1', per_page: '10' });
 
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({
-          ok: true,
-          headers,
-          json: () => Promise.resolve([]),
-        })
-      );
+      stubJsonResponse([], { headers });
 
       const client = new GenericClient(() => '#/categories?page=2');
       await client.fetchIndex('/categories.json');
@@ -114,13 +92,7 @@ describe('GenericClient', function() {
     it('does not append query string when hash has no params', async function() {
       const headers = buildResponseHeaders({ page: '1', pages: '1', per_page: '10' });
 
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({
-          ok: true,
-          headers,
-          json: () => Promise.resolve([]),
-        })
-      );
+      stubJsonResponse([], { headers });
 
       const client = new GenericClient(() => '#/categories');
       await client.fetchIndex('/categories.json');
@@ -131,13 +103,7 @@ describe('GenericClient', function() {
     it('falls back to defaults when pagination headers are absent', async function() {
       const headers = buildResponseHeaders();
 
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({
-          ok: true,
-          headers,
-          json: () => Promise.resolve([]),
-        })
-      );
+      stubJsonResponse([], { headers });
 
       const client = new GenericClient(() => '');
       const result = await client.fetchIndex('/categories.json');
@@ -146,9 +112,7 @@ describe('GenericClient', function() {
     });
 
     it('throws on non-ok response', async function() {
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({ ok: false, status: 500 })
-      );
+      stubFetchResponse({ ok: false, status: 500 });
 
       const client = new GenericClient(() => '');
 

--- a/frontend/spec/client/HeaderClient_spec.js
+++ b/frontend/spec/client/HeaderClient_spec.js
@@ -1,21 +1,20 @@
 import HeaderClient from '../../assets/js/client/HeaderClient.js';
+import { preserveGlobals, stubFetchResponse } from '../support/factories.js';
 
 describe('HeaderClient', function() {
-  let originalFetch;
+  let restoreGlobals;
 
   beforeEach(function() {
-    originalFetch = global.fetch;
+    restoreGlobals = preserveGlobals('fetch');
   });
 
   afterEach(function() {
-    global.fetch = originalFetch;
+    restoreGlobals();
   });
 
   describe('#checkLogin', function() {
     it('sends a GET request to the login status endpoint', async function() {
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({ ok: true })
-      );
+      stubFetchResponse({ ok: true });
 
       const client = new HeaderClient();
 
@@ -29,9 +28,7 @@ describe('HeaderClient', function() {
 
   describe('#fetchCategories', function() {
     it('sends a GET request to the user categories endpoint', async function() {
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
-      );
+      stubFetchResponse({ ok: true, json: () => Promise.resolve([]) });
 
       const client = new HeaderClient();
 
@@ -45,9 +42,7 @@ describe('HeaderClient', function() {
 
   describe('#logoff', function() {
     it('sends a DELETE request to the logoff endpoint', async function() {
-      global.fetch = jasmine.createSpy('fetch').and.returnValue(
-        Promise.resolve({ ok: true })
-      );
+      stubFetchResponse({ ok: true });
 
       const client = new HeaderClient();
 

--- a/frontend/spec/client/LoginModalClient_spec.js
+++ b/frontend/spec/client/LoginModalClient_spec.js
@@ -1,18 +1,19 @@
 import LoginModalClient from '../../assets/js/client/LoginModalClient.js';
+import { preserveGlobals, stubFetchResponse } from '../support/factories.js';
 
 describe('LoginModalClient', function() {
-  let originalFetch;
+  let restoreGlobals;
 
   beforeEach(function() {
-    originalFetch = global.fetch;
+    restoreGlobals = preserveGlobals('fetch');
   });
 
   afterEach(function() {
-    global.fetch = originalFetch;
+    restoreGlobals();
   });
 
   it('submits the login payload to the json endpoint', async function() {
-    global.fetch = jasmine.createSpy('fetch').and.returnValue(Promise.resolve({ ok: true }));
+    stubFetchResponse({ ok: true });
 
     const client = new LoginModalClient();
 

--- a/frontend/spec/components/App_spec.js
+++ b/frontend/spec/components/App_spec.js
@@ -1,29 +1,25 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import React from 'react';
 import App from '../../assets/js/components/App.jsx';
+import { preserveGlobals, stubFetchResponse } from '../support/factories.js';
 
 describe('App', function() {
-  let originalWindow;
-  let originalFetch;
+  let restoreGlobals;
+
+  const buildWindow = () => ({
+    location: { hash: '' },
+    addEventListener: jasmine.createSpy('addEventListener'),
+    removeEventListener: jasmine.createSpy('removeEventListener'),
+  });
 
   beforeEach(function() {
-    originalWindow = global.window;
-    originalFetch = global.fetch;
-
-    global.window = {
-      location: { hash: '' },
-      addEventListener: jasmine.createSpy('addEventListener'),
-      removeEventListener: jasmine.createSpy('removeEventListener'),
-    };
-
-    global.fetch = jasmine.createSpy('fetch').and.returnValue(
-      Promise.resolve({ ok: false, status: 404 })
-    );
+    restoreGlobals = preserveGlobals('window', 'fetch');
+    global.window = buildWindow();
+    stubFetchResponse({ ok: false, status: 404 });
   });
 
   afterEach(function() {
-    global.window = originalWindow;
-    global.fetch = originalFetch;
+    restoreGlobals();
   });
 
   it('renders the navigation header', function() {

--- a/frontend/spec/components/elements/controllers/HeaderController_spec.js
+++ b/frontend/spec/components/elements/controllers/HeaderController_spec.js
@@ -1,29 +1,33 @@
 import HeaderController from '../../../../assets/js/components/elements/controllers/HeaderController.js';
-
-const flushPromises = async () => {
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
-};
+import {
+  buildSpies,
+  flushPromises,
+  preserveGlobals,
+  stubFetch,
+} from '../../../support/factories.js';
 
 describe('HeaderController', function() {
-  let originalFetch;
+  let restoreGlobals;
+
+  const buildSetters = () => buildSpies(
+    'setLogged',
+    'setCategories',
+    'setLoading',
+    'setError'
+  );
 
   beforeEach(function() {
-    originalFetch = global.fetch;
+    restoreGlobals = preserveGlobals('fetch');
   });
 
   afterEach(function() {
-    global.fetch = originalFetch;
+    restoreGlobals();
   });
 
   it('loads login state and categories in buildEffect', async function() {
-    const setLogged = jasmine.createSpy('setLogged');
-    const setCategories = jasmine.createSpy('setCategories');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setLogged, setCategories, setLoading, setError } = buildSetters();
 
-    global.fetch = jasmine.createSpy('fetch').and.callFake((url) => {
+    stubFetch((url) => {
       if (url === '/users/login.json') {
         return Promise.resolve({
           ok: true,
@@ -58,12 +62,9 @@ describe('HeaderController', function() {
   });
 
   it('handles non-logged users when login check returns 404', async function() {
-    const setLogged = jasmine.createSpy('setLogged');
-    const setCategories = jasmine.createSpy('setCategories');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setLogged, setCategories, setLoading, setError } = buildSetters();
 
-    global.fetch = jasmine.createSpy('fetch').and.callFake((url) => {
+    stubFetch((url) => {
       if (url === '/users/login.json') {
         return Promise.resolve({ ok: false, status: 404 });
       }
@@ -90,12 +91,9 @@ describe('HeaderController', function() {
   });
 
   it('logs off and reloads categories', async function() {
-    const setLogged = jasmine.createSpy('setLogged');
-    const setCategories = jasmine.createSpy('setCategories');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setLogged, setCategories, setLoading, setError } = buildSetters();
 
-    global.fetch = jasmine.createSpy('fetch').and.callFake((url) => {
+    stubFetch((url) => {
       if (url === '/users/logoff.json') {
         return Promise.resolve({ ok: true });
       }
@@ -127,12 +125,9 @@ describe('HeaderController', function() {
   });
 
   it('reloads header data on demand', async function() {
-    const setLogged = jasmine.createSpy('setLogged');
-    const setCategories = jasmine.createSpy('setCategories');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setLogged, setCategories, setLoading, setError } = buildSetters();
 
-    global.fetch = jasmine.createSpy('fetch').and.callFake((url) => {
+    stubFetch((url) => {
       if (url === '/users/login.json') {
         return Promise.resolve({
           ok: true,

--- a/frontend/spec/components/helpers/AppHelper_spec.js
+++ b/frontend/spec/components/helpers/AppHelper_spec.js
@@ -2,51 +2,53 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import AppHelper from '../../../assets/js/components/helpers/AppHelper.jsx';
 
 describe('AppHelper', function() {
+  const renderPage = (page) => renderToStaticMarkup(AppHelper.render(page));
+
   describe('.render', function() {
     it('renders the header', function() {
-      const html = renderToStaticMarkup(AppHelper.render('home'));
+      const html = renderPage('home');
 
       expect(html).toContain('Oak');
     });
 
     it('renders the home placeholder for "home" page', function() {
-      const html = renderToStaticMarkup(AppHelper.render('home'));
+      const html = renderPage('home');
 
       expect(html).toContain('placeholder');
     });
 
     it('does not render Categories for "home" page', function() {
-      const html = renderToStaticMarkup(AppHelper.render('home'));
+      const html = renderPage('home');
 
       expect(html).not.toContain('Loading categories...');
     });
 
     it('does not render CategoryItems for "home" page', function() {
-      const html = renderToStaticMarkup(AppHelper.render('home'));
+      const html = renderPage('home');
 
       expect(html).not.toContain('Loading category items...');
     });
 
     it('renders the Categories component for "categories" page', function() {
-      const html = renderToStaticMarkup(AppHelper.render('categories'));
+      const html = renderPage('categories');
 
       expect(html).toContain('Loading categories...');
     });
 
     it('does not render the home placeholder for "categories" page', function() {
-      const html = renderToStaticMarkup(AppHelper.render('categories'));
+      const html = renderPage('categories');
 
       expect(html).not.toContain('placeholder');
     });
 
     it('renders the CategoryItems component for "categoryItems" page', function() {
-      const html = renderToStaticMarkup(AppHelper.render('categoryItems'));
+      const html = renderPage('categoryItems');
 
       expect(html).toContain('Loading category items...');
     });
 
     it('renders the CategoryItem component for "categoryItem" page', function() {
-      const html = renderToStaticMarkup(AppHelper.render('categoryItem'));
+      const html = renderPage('categoryItem');
 
       expect(html).toContain('Loading category item...');
     });

--- a/frontend/spec/components/pages/controllers/CategoriesController_spec.js
+++ b/frontend/spec/components/pages/controllers/CategoriesController_spec.js
@@ -1,8 +1,13 @@
 import CategoriesController from '../../../../assets/js/components/pages/controllers/CategoriesController.js';
-import { flushPromises, stubLoginFetch } from '../../../support/factories.js';
+import {
+  buildSpies,
+  flushPromises,
+  preserveGlobals,
+  stubLoginFetch,
+} from '../../../support/factories.js';
 
 describe('CategoriesController', function() {
-  let originalFetch;
+  let restoreGlobals;
   let mockClient;
 
   const buildMockClient = (overrides = {}) => ({
@@ -12,21 +17,25 @@ describe('CategoriesController', function() {
     ...overrides,
   });
 
+  const buildSetters = () => buildSpies(
+    'setCategories',
+    'setPagination',
+    'setLogged',
+    'setLoading',
+    'setError'
+  );
+
   beforeEach(function() {
-    originalFetch = global.fetch;
+    restoreGlobals = preserveGlobals('fetch');
     mockClient = buildMockClient();
   });
 
   afterEach(function() {
-    global.fetch = originalFetch;
+    restoreGlobals();
   });
 
   it('fetches categories and login state in buildEffect', async function() {
-    const setCategories = jasmine.createSpy('setCategories');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setCategories, setPagination, setLogged, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       fetchIndex: jasmine.createSpy('fetchIndex').and.returnValue(
@@ -59,11 +68,7 @@ describe('CategoriesController', function() {
   });
 
   it('sets logged to false when login returns 404', async function() {
-    const setCategories = jasmine.createSpy('setCategories');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setCategories, setPagination, setLogged, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       fetchIndex: jasmine.createSpy('fetchIndex').and.returnValue(
@@ -89,11 +94,7 @@ describe('CategoriesController', function() {
   });
 
   it('calls client.fetchIndex with /categories.json', async function() {
-    const setCategories = jasmine.createSpy('setCategories');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setCategories, setPagination, setLogged, setLoading, setError } = buildSetters();
 
     stubLoginFetch(404);
 
@@ -112,11 +113,7 @@ describe('CategoriesController', function() {
   });
 
   it('calls setError when categories fetch fails', async function() {
-    const setCategories = jasmine.createSpy('setCategories');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setCategories, setPagination, setLogged, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       fetchIndex: jasmine.createSpy('fetchIndex').and.returnValue(
@@ -140,11 +137,7 @@ describe('CategoriesController', function() {
   });
 
   it('does not call setters after unmount', async function() {
-    const setCategories = jasmine.createSpy('setCategories');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setCategories, setPagination, setLogged, setLoading, setError } = buildSetters();
 
     stubLoginFetch(404);
 
@@ -165,11 +158,7 @@ describe('CategoriesController', function() {
   });
 
   it('applies fallback pagination when client returns minimal pagination', async function() {
-    const setCategories = jasmine.createSpy('setCategories');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setCategories, setPagination, setLogged, setLoading, setError } = buildSetters();
 
     stubLoginFetch(404);
 
@@ -189,11 +178,7 @@ describe('CategoriesController', function() {
   });
 
   it('calls global.fetch directly for login check', async function() {
-    const setCategories = jasmine.createSpy('setCategories');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setCategories, setPagination, setLogged, setLoading, setError } = buildSetters();
 
     stubLoginFetch(404);
 
@@ -210,4 +195,3 @@ describe('CategoriesController', function() {
     cleanup();
   });
 });
-

--- a/frontend/spec/components/pages/controllers/CategoryItemController_spec.js
+++ b/frontend/spec/components/pages/controllers/CategoryItemController_spec.js
@@ -1,8 +1,13 @@
 import CategoryItemController, { getCategoryItemParamsFromHash } from '../../../../assets/js/components/pages/controllers/CategoryItemController.js';
-import { flushPromises, stubLoginFetch } from '../../../support/factories.js';
+import {
+  buildSpies,
+  flushPromises,
+  preserveGlobals,
+  stubLoginFetch,
+} from '../../../support/factories.js';
 
 describe('CategoryItemController', function() {
-  let originalFetch;
+  let restoreGlobals;
   let mockClient;
 
   const buildMockClient = (overrides = {}) => ({
@@ -13,13 +18,20 @@ describe('CategoryItemController', function() {
     ...overrides,
   });
 
+  const buildSetters = () => buildSpies(
+    'setItem',
+    'setLogged',
+    'setLoading',
+    'setError'
+  );
+
   beforeEach(function() {
-    originalFetch = global.fetch;
+    restoreGlobals = preserveGlobals('fetch');
     mockClient = buildMockClient();
   });
 
   afterEach(function() {
-    global.fetch = originalFetch;
+    restoreGlobals();
   });
 
   describe('getCategoryItemParamsFromHash', function() {
@@ -31,10 +43,7 @@ describe('CategoryItemController', function() {
   });
 
   it('fetches category item and login state in buildEffect', async function() {
-    const setItem = jasmine.createSpy('setItem');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItem, setLogged, setLoading, setError } = buildSetters();
     const item = {
       id: 35,
       name: 'Oak',
@@ -66,10 +75,7 @@ describe('CategoryItemController', function() {
   });
 
   it('sets logged to false when login returns 404', async function() {
-    const setItem = jasmine.createSpy('setItem');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItem, setLogged, setLoading, setError } = buildSetters();
 
     stubLoginFetch(404);
 
@@ -86,10 +92,7 @@ describe('CategoryItemController', function() {
   });
 
   it('calls setError when category item fetch fails', async function() {
-    const setItem = jasmine.createSpy('setItem');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItem, setLogged, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/project/items/35'),
@@ -111,10 +114,7 @@ describe('CategoryItemController', function() {
   });
 
   it('calls setError when params cannot be extracted from hash', async function() {
-    const setItem = jasmine.createSpy('setItem');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItem, setLogged, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/project/items'),
@@ -134,10 +134,7 @@ describe('CategoryItemController', function() {
   });
 
   it('does not call setters after unmount', async function() {
-    const setItem = jasmine.createSpy('setItem');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItem, setLogged, setLoading, setError } = buildSetters();
 
     stubLoginFetch(404);
 

--- a/frontend/spec/components/pages/controllers/CategoryItemsController_spec.js
+++ b/frontend/spec/components/pages/controllers/CategoryItemsController_spec.js
@@ -1,8 +1,13 @@
 import CategoryItemsController from '../../../../assets/js/components/pages/controllers/CategoryItemsController.js';
-import { flushPromises, stubLoginFetch } from '../../../support/factories.js';
+import {
+  buildSpies,
+  flushPromises,
+  preserveGlobals,
+  stubLoginFetch,
+} from '../../../support/factories.js';
 
 describe('CategoryItemsController', function() {
-  let originalFetch;
+  let restoreGlobals;
   let mockClient;
 
   const buildMockClient = (overrides = {}) => ({
@@ -13,21 +18,25 @@ describe('CategoryItemsController', function() {
     ...overrides,
   });
 
+  const buildSetters = () => buildSpies(
+    'setItems',
+    'setLogged',
+    'setPagination',
+    'setLoading',
+    'setError'
+  );
+
   beforeEach(function() {
-    originalFetch = global.fetch;
+    restoreGlobals = preserveGlobals('fetch');
     mockClient = buildMockClient();
   });
 
   afterEach(function() {
-    global.fetch = originalFetch;
+    restoreGlobals();
   });
 
   it('fetches category items and login state in buildEffect', async function() {
-    const setItems = jasmine.createSpy('setItems');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItems, setLogged, setPagination, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/project/items?page=2&per_page=12'),
@@ -60,11 +69,7 @@ describe('CategoryItemsController', function() {
   });
 
   it('sets logged to false when login returns 404', async function() {
-    const setItems = jasmine.createSpy('setItems');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItems, setLogged, setPagination, setLoading, setError } = buildSetters();
 
     stubLoginFetch(404);
 
@@ -84,11 +89,7 @@ describe('CategoryItemsController', function() {
   });
 
   it('calls setError when category items fetch fails', async function() {
-    const setItems = jasmine.createSpy('setItems');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItems, setLogged, setPagination, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/project/items'),
@@ -112,11 +113,7 @@ describe('CategoryItemsController', function() {
   });
 
   it('calls setError when slug cannot be extracted from hash', async function() {
-    const setItems = jasmine.createSpy('setItems');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItems, setLogged, setPagination, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories'),
@@ -138,11 +135,7 @@ describe('CategoryItemsController', function() {
   });
 
   it('does not call setters after unmount', async function() {
-    const setItems = jasmine.createSpy('setItems');
-    const setLogged = jasmine.createSpy('setLogged');
-    const setPagination = jasmine.createSpy('setPagination');
-    const setLoading = jasmine.createSpy('setLoading');
-    const setError = jasmine.createSpy('setError');
+    const { setItems, setLogged, setPagination, setLoading, setError } = buildSetters();
 
     stubLoginFetch(404);
 

--- a/frontend/spec/main_spec.js
+++ b/frontend/spec/main_spec.js
@@ -1,30 +1,23 @@
 import { mount } from '../assets/js/main.jsx';
+import { preserveGlobals, stubFetchResponse } from './support/factories.js';
 
 describe('main', function() {
-  let originalDocument;
-  let originalWindow;
-  let originalFetch;
+  let restoreGlobals;
+
+  const buildWindow = () => ({
+    location: { hash: '' },
+    addEventListener: jasmine.createSpy('addEventListener'),
+    removeEventListener: jasmine.createSpy('removeEventListener'),
+  });
 
   beforeEach(function() {
-    originalDocument = global.document;
-    originalWindow = global.window;
-    originalFetch = global.fetch;
-
-    global.window = {
-      location: { hash: '' },
-      addEventListener: jasmine.createSpy('addEventListener'),
-      removeEventListener: jasmine.createSpy('removeEventListener'),
-    };
-
-    global.fetch = jasmine.createSpy('fetch').and.returnValue(
-      Promise.resolve({ ok: false, status: 404 })
-    );
+    restoreGlobals = preserveGlobals('document', 'window', 'fetch');
+    global.window = buildWindow();
+    stubFetchResponse({ ok: false, status: 404 });
   });
 
   afterEach(function() {
-    global.document = originalDocument;
-    global.window = originalWindow;
-    global.fetch = originalFetch;
+    restoreGlobals();
   });
 
   describe('#mount', function() {

--- a/frontend/spec/support/factories.js
+++ b/frontend/spec/support/factories.js
@@ -4,8 +4,40 @@ export const flushPromises = async () => {
   });
 };
 
+export const buildSpies = (...names) => {
+  const spies = {};
+
+  for (const name of names) {
+    spies[name] = jasmine.createSpy(name);
+  }
+
+  return spies;
+};
+
+export const preserveGlobals = (...names) => {
+  const originals = Object.fromEntries(
+    names.map((name) => [name, global[name]])
+  );
+
+  return () => {
+    names.forEach((name) => {
+      global[name] = originals[name];
+    });
+  };
+};
+
+export const stubFetch = (implementation) => {
+  global.fetch = jasmine.createSpy('fetch').and.callFake(implementation);
+
+  return global.fetch;
+};
+
+export const stubFetchResponse = (response) => stubFetch(
+  () => Promise.resolve(response)
+);
+
 export const stubLoginFetch = (status = 404) => {
-  global.fetch = jasmine.createSpy('fetch').and.callFake((url) => {
+  stubFetch((url) => {
     if (url === '/users/login.json') {
       if (status === 200) {
         return Promise.resolve({


### PR DESCRIPTION
The frontend specs had repeated setup for global state, fetch stubbing, and controller spies, which made the suite noisy and harder to maintain. This refactor centralizes those patterns in shared support helpers and trims repetitive setup from the most duplicated spec files without changing coverage intent.

- **Shared spec support**
  - Expanded `frontend/spec/support/factories.js` with reusable helpers for:
    - preserving/restoring globals
    - building named Jasmine spies
    - stubbing `fetch` with fixed responses or custom handlers
  - Reused the existing async flush helper instead of redefining it per file

- **Controller spec cleanup**
  - Replaced repeated setter spy declarations in page/header controller specs with shared `buildSpies(...)`
  - Replaced repeated `global.fetch` save/restore blocks with a shared global preservation helper
  - Consolidated fetch stubbing logic so login/header request scenarios are declared inline without the surrounding boilerplate

- **Client/component spec cleanup**
  - Removed repeated fetch response setup in client specs via a shared `stubFetchResponse(...)`
  - Simplified `main_spec.js` and `App_spec.js` by extracting repeated window/fetch setup
  - Reduced repeated render boilerplate in `AppHelper_spec.js` with a small local helper

- **Representative simplification**
  ```js
  const { setCategories, setPagination, setLogged, setLoading, setError } = buildSpies(
    'setCategories',
    'setPagination',
    'setLogged',
    'setLoading',
    'setError'
  );

  const restoreGlobals = preserveGlobals('fetch');
  stubFetchResponse({ ok: false, status: 500 });
  ```