### PR TITLE
Increase frontend spec coverage for pagination and category item controller flows

### DIFF
--- a/frontend/spec/components/elements/controllers/PaginationBuilder_spec.js
+++ b/frontend/spec/components/elements/controllers/PaginationBuilder_spec.js
@@ -57,7 +57,15 @@ describe('PaginationBuilder', function() {
 
       builder.addCurrentPageWindow();
 
-      expect(builder.build()).not.toContain(0);
+      expect(builder.build()).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('filters out pages above the total near the end', function() {
+      const builder = new PaginationBuilder(19, 20);
+
+      builder.addCurrentPageWindow();
+
+      expect(builder.build()).toEqual([16, 17, 18, 19, 20]);
     });
   });
 
@@ -94,6 +102,16 @@ describe('PaginationBuilder', function() {
       builder.addCurrentPageWindow();
 
       expect(builder.build()).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('returns sorted pages regardless of insertion order', function() {
+      const builder = new PaginationBuilder(10, 20);
+
+      builder.addLastPages();
+      builder.addCurrentPageWindow();
+      builder.addFirstPages();
+
+      expect(builder.build()).toEqual([1, 2, 3, null, 7, 8, 9, 10, 11, 12, 13, null, 18, 19, 20]);
     });
   });
 });

--- a/frontend/spec/components/pages/controllers/CategoryItemController_spec.js
+++ b/frontend/spec/components/pages/controllers/CategoryItemController_spec.js
@@ -3,6 +3,7 @@ import {
   buildSpies,
   flushPromises,
   preserveGlobals,
+  stubFetch,
   stubLoginFetch,
 } from '../../../support/factories.js';
 
@@ -39,6 +40,18 @@ describe('CategoryItemController', function() {
       const params = getCategoryItemParamsFromHash('#/categories/project/items/35?page=2');
 
       expect(params).toEqual({ slug: 'project', id: '35' });
+    });
+
+    it('extracts slug and id from a route with a trailing slash', function() {
+      const params = getCategoryItemParamsFromHash('#/categories/project/items/35/?page=2');
+
+      expect(params).toEqual({ slug: 'project', id: '35' });
+    });
+
+    it('returns empty params when the hash does not match the item route', function() {
+      const params = getCategoryItemParamsFromHash('#/categories/project/items');
+
+      expect(params).toEqual({ slug: '', id: '' });
     });
   });
 
@@ -91,6 +104,23 @@ describe('CategoryItemController', function() {
     cleanup();
   });
 
+  it('sets logged to false when login returns 401', async function() {
+    const { setItem, setLogged, setLoading, setError } = buildSetters();
+
+    stubLoginFetch(401);
+
+    const controller = new CategoryItemController(setItem, setLogged, setLoading, setError, mockClient);
+    const cleanup = controller.buildEffect()();
+
+    await flushPromises();
+
+    expect(setLogged).toHaveBeenCalledWith(false);
+    expect(setLoading).toHaveBeenCalledWith(false);
+    expect(setError).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
   it('calls setError when category item fetch fails', async function() {
     const { setItem, setLogged, setLoading, setError } = buildSetters();
 
@@ -108,6 +138,30 @@ describe('CategoryItemController', function() {
     await flushPromises();
 
     expect(setError).toHaveBeenCalledWith('Unable to load category item.');
+    expect(setLoading).toHaveBeenCalledWith(false);
+
+    cleanup();
+  });
+
+  it('calls setError when login check returns an unexpected status', async function() {
+    const { setItem, setLogged, setLoading, setError } = buildSetters();
+
+    stubFetch((url) => {
+      if (url === '/users/login.json') {
+        return Promise.resolve({ ok: false, status: 500 });
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const controller = new CategoryItemController(setItem, setLogged, setLoading, setError, mockClient);
+    const cleanup = controller.buildEffect()();
+
+    await flushPromises();
+
+    expect(setItem).not.toHaveBeenCalled();
+    expect(setLogged).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenCalledWith('Unable to check login status.');
     expect(setLoading).toHaveBeenCalledWith(false);
 
     cleanup();


### PR DESCRIPTION

This PR expands frontend coverage for the two files called out in the issue: sparse pagination list building and category-item route/effect handling. The updates focus on uncovered edge cases and failure branches without changing production behavior.

- **PaginationBuilder coverage**
  - Adds assertions for current-page windows near the beginning and end of the range
  - Verifies page ordering is stable regardless of insertion order
  - Strengthens coverage around bounded ranges and sparse output generation

- **CategoryItemController route parsing**
  - Covers valid hash parsing with query strings and optional trailing slash
  - Covers unmatched hashes returning empty `slug`/`id` params

- **CategoryItemController async/login branches**
  - Adds login handling coverage for unauthorized responses (`401`) returning `false`
  - Covers unexpected login status failures surfacing the controller error path
  - Preserves existing success, fetch failure, invalid route, and unmount/cleanup expectations

- **Representative cases**
```javascript
expect(getCategoryItemParamsFromHash('#/categories/project/items/35/?page=2'))
  .toEqual({ slug: 'project', id: '35' });

const builder = new PaginationBuilder(19, 20);
builder.addCurrentPageWindow();

expect(builder.build()).toEqual([16, 17, 18, 19, 20]);
```

Fixes #135