### PR TITLE
Render categories index on the home page

### DIFF
--- a/frontend/assets/js/components/helpers/AppHelper.jsx
+++ b/frontend/assets/js/components/helpers/AppHelper.jsx
@@ -9,7 +9,7 @@ const PAGES = {
   categories: <Categories />,
   categoryItem: <CategoryItem />,
   categoryItems: <CategoryItems />,
-  home: <p>placeholder</p>,
+  home: <Categories />,
   kinds: <Kinds />,
 };
 

--- a/frontend/spec/components/App_spec.js
+++ b/frontend/spec/components/App_spec.js
@@ -28,11 +28,11 @@ describe('App', function() {
     expect(html).toContain('Oak');
   });
 
-  it('renders the home placeholder when the hash is empty', function() {
+  it('renders the categories page when the hash is empty', function() {
     global.window.location.hash = '';
 
     const html = renderToStaticMarkup(React.createElement(App));
 
-    expect(html).toContain('placeholder');
+    expect(html).toContain('Loading categories...');
   });
 });

--- a/frontend/spec/components/helpers/AppHelper_spec.js
+++ b/frontend/spec/components/helpers/AppHelper_spec.js
@@ -11,16 +11,16 @@ describe('AppHelper', function() {
       expect(html).toContain('Oak');
     });
 
-    it('renders the home placeholder for "home" page', function() {
+    it('renders the Categories component for "home" page', function() {
       const html = renderPage('home');
 
-      expect(html).toContain('placeholder');
+      expect(html).toContain('Loading categories...');
     });
 
-    it('does not render Categories for "home" page', function() {
+    it('does not render the home placeholder for "home" page', function() {
       const html = renderPage('home');
 
-      expect(html).not.toContain('Loading categories...');
+      expect(html).not.toContain('placeholder');
     });
 
     it('does not render CategoryItems for "home" page', function() {


### PR DESCRIPTION
The home page was still rendering a placeholder in the React app, even though the server response already uses the categories index view. This change makes the client render the categories index content in place for `/`, without changing the route or introducing a redirect.

- **Home page rendering**
  - Mapped the `home` page entry in `AppHelper` to the existing `Categories` page component.
  - Preserves the current app flow while making the root view behave like the categories index.

- **Behavioral coverage**
  - Updated home-page component specs to assert categories content is rendered for the empty-hash/root case.
  - Removed expectations tied to the old placeholder output.

- **Implementation shape**
  - Reused the existing categories page instead of adding a separate home-specific variant.

```jsx
const PAGES = {
  categories: <Categories />,
  categoryItem: <CategoryItem />,
  categoryItems: <CategoryItems />,
  home: <Categories />,
  kinds: <Kinds />,
};
```

Fixes #155 