### PR TITLE
Introduce Router and Route abstractions to replace hard-coded regex routing in HashRouteResolver

### DIFF
--- a/frontend/assets/js/utils/HashRouteResolver.js
+++ b/frontend/assets/js/utils/HashRouteResolver.js
@@ -1,9 +1,28 @@
+import Router from './Router.js';
+
 /**
  * Resolves routing information from the current hash URL.
  */
 export default class HashRouteResolver {
   /** @type {Function} */
   #hashProvider;
+
+  /** @type {Router} */
+  #router;
+
+  /**
+   * Builds the Router instance with all known application routes registered.
+   *
+   * @returns {Router} configured router
+   */
+  static #buildRouter() {
+    const router = new Router();
+    router.register('/categories/:slug/items/:id', 'categoryItem');
+    router.register('/categories/:slug/items', 'categoryItems');
+    router.register('/categories', 'categories');
+    router.register('/kinds', 'kinds');
+    return router;
+  }
 
   /**
    * Creates a new resolver instance.
@@ -12,6 +31,7 @@ export default class HashRouteResolver {
    */
   constructor(hashProvider = () => (typeof window === 'undefined' ? '' : window.location.hash)) {
     this.#hashProvider = hashProvider;
+    this.#router = HashRouteResolver.#buildRouter();
   }
 
   /**
@@ -26,28 +46,16 @@ export default class HashRouteResolver {
   /**
    * Resolves the current page identifier from the hash route.
    *
+   * Query parameters are stripped before matching so that hashes like
+   * `#/categories?page=2` correctly resolve to `'categories'`.
+   *
    * @returns {string} page identifier
    */
   getPage() {
     const hash = this.currentHash();
-
-    if (/^#\/categories\/[^/]+\/items\/[^/]+\/?(\?.*)?$/.test(hash)) {
-      return 'categoryItem';
-    }
-
-    if (/^#\/categories\/[^/]+\/items\/?(\?.*)?$/.test(hash)) {
-      return 'categoryItems';
-    }
-
-    if (/^#\/categories\/?(\?.*)?$/.test(hash)) {
-      return 'categories';
-    }
-
-    if (/^#\/kinds\/?(\?.*)?$/.test(hash)) {
-      return 'kinds';
-    }
-
-    return 'home';
+    const withoutHash = hash.startsWith('#') ? hash.slice(1) : hash;
+    const route = withoutHash.split('?')[0];
+    return this.#router.resolve(route);
   }
 
   /**

--- a/frontend/assets/js/utils/Route.js
+++ b/frontend/assets/js/utils/Route.js
@@ -1,0 +1,45 @@
+/**
+ * Represents a single registered route, encapsulating the compiled regex and
+ * the associated page identifier.
+ */
+export default class Route {
+  /** @type {RegExp} */
+  #regex;
+
+  /** @type {string} */
+  #page;
+
+  /**
+   * Creates a new Route from a path pattern and a page identifier.
+   *
+   * `:param` segments in the pattern are compiled to `[^/]+` regex fragments.
+   * A trailing slash is always optional in the compiled pattern.
+   *
+   * @param {string} path path pattern (e.g. '/categories/:slug/items')
+   * @param {string} page page identifier to associate with this route
+   */
+  constructor(path, page) {
+    const pattern = path.replace(/:([^/]+)/g, '[^/]+');
+    this.#regex = new RegExp(`^${pattern}/?$`);
+    this.#page = page;
+  }
+
+  /**
+   * Tests whether this route matches the given path.
+   *
+   * @param {string} route route path to test (without query string)
+   * @returns {boolean} true if this route matches
+   */
+  matches(route) {
+    return this.#regex.test(route);
+  }
+
+  /**
+   * Returns the page identifier for this route.
+   *
+   * @returns {string} page identifier
+   */
+  get page() {
+    return this.#page;
+  }
+}

--- a/frontend/assets/js/utils/Router.js
+++ b/frontend/assets/js/utils/Router.js
@@ -1,0 +1,77 @@
+import Route from './Route.js';
+
+/**
+ * Manages route registration and resolution.
+ *
+ * Maintains a class-level singleton registry that delegates to an instance.
+ * Routes are registered with path patterns (supporting `:param` segments) and
+ * associated page identifiers.
+ */
+export default class Router {
+  /** @type {Router|null} */
+  static #registry = null;
+
+  /** @type {Array<Route>} */
+  #routes = [];
+
+  /**
+   * Returns the singleton registry instance, creating it if necessary.
+   *
+   * @returns {Router} registry instance
+   */
+  static #getRegistry() {
+    if (!Router.#registry) {
+      Router.#registry = new Router();
+    }
+    return Router.#registry;
+  }
+
+  /**
+   * Registers a route path pattern with a page name in the class-level registry.
+   *
+   * @param {string} path route path pattern (e.g. '/categories/:slug/items')
+   * @param {string} page page identifier to associate with this route
+   */
+  static register(path, page) {
+    Router.#getRegistry().register(path, page);
+  }
+
+  /**
+   * Resolves a route path to a page identifier using the class-level registry.
+   *
+   * @param {string} route route path to resolve (without query string)
+   * @returns {string} page identifier, or 'home' if no match is found
+   */
+  static resolve(route) {
+    return Router.#getRegistry().resolve(route);
+  }
+
+  /**
+   * Resets the class-level registry. Useful for testing.
+   */
+  static reset() {
+    Router.#registry = null;
+  }
+
+  /**
+   * Registers a route path pattern with a page name.
+   *
+   * @param {string} path route path pattern (e.g. '/categories/:slug/items')
+   * @param {string} page page identifier to associate with this route
+   */
+  register(path, page) {
+    this.#routes.push(new Route(path, page));
+  }
+
+  /**
+   * Resolves a route path to a page identifier.
+   *
+   * @param {string} route route path to resolve (without query string)
+   * @returns {string} page identifier, or 'home' if no match is found
+   */
+  resolve(route) {
+    const match = this.#routes.find((r) => r.matches(route));
+    return match ? match.page : 'home';
+  }
+}
+

--- a/frontend/spec/utils/Route_spec.js
+++ b/frontend/spec/utils/Route_spec.js
@@ -1,0 +1,49 @@
+import Route from '../../assets/js/utils/Route.js';
+
+describe('Route', function() {
+  describe('#matches', function() {
+    it('matches an exact path', function() {
+      const route = new Route('/categories', 'categories');
+
+      expect(route.matches('/categories')).toBe(true);
+    });
+
+    it('matches a path with a trailing slash', function() {
+      const route = new Route('/categories', 'categories');
+
+      expect(route.matches('/categories/')).toBe(true);
+    });
+
+    it('matches a path with a :param segment', function() {
+      const route = new Route('/categories/:slug/items', 'categoryItems');
+
+      expect(route.matches('/categories/project/items')).toBe(true);
+    });
+
+    it('matches a path with multiple :param segments', function() {
+      const route = new Route('/categories/:slug/items/:id', 'categoryItem');
+
+      expect(route.matches('/categories/project/items/42')).toBe(true);
+    });
+
+    it('does not match a partial path', function() {
+      const route = new Route('/categories', 'categories');
+
+      expect(route.matches('/categories/extra')).toBe(false);
+    });
+
+    it('does not match an unrelated path', function() {
+      const route = new Route('/categories', 'categories');
+
+      expect(route.matches('/kinds')).toBe(false);
+    });
+  });
+
+  describe('#page', function() {
+    it('returns the page identifier', function() {
+      const route = new Route('/categories', 'categories');
+
+      expect(route.page).toBe('categories');
+    });
+  });
+});

--- a/frontend/spec/utils/Router_spec.js
+++ b/frontend/spec/utils/Router_spec.js
@@ -1,0 +1,97 @@
+import Router from '../../assets/js/utils/Router.js';
+
+describe('Router', function() {
+  describe('instance methods', function() {
+    let router;
+
+    beforeEach(function() {
+      router = new Router();
+    });
+
+    describe('#register and #resolve', function() {
+      it('resolves a registered exact route', function() {
+        router.register('/categories', 'categories');
+
+        expect(router.resolve('/categories')).toBe('categories');
+      });
+
+      it('resolves a route with a trailing slash', function() {
+        router.register('/categories', 'categories');
+
+        expect(router.resolve('/categories/')).toBe('categories');
+      });
+
+      it('resolves a route with a slug param', function() {
+        router.register('/categories/:slug/items', 'categoryItems');
+
+        expect(router.resolve('/categories/project/items')).toBe('categoryItems');
+      });
+
+      it('resolves a route with multiple params', function() {
+        router.register('/categories/:slug/items/:id', 'categoryItem');
+
+        expect(router.resolve('/categories/project/items/42')).toBe('categoryItem');
+      });
+
+      it('returns "home" for unmatched routes', function() {
+        expect(router.resolve('/unknown')).toBe('home');
+      });
+
+      it('matches routes in registration order', function() {
+        router.register('/categories/:slug/items/:id', 'categoryItem');
+        router.register('/categories/:slug/items', 'categoryItems');
+
+        expect(router.resolve('/categories/project/items/42')).toBe('categoryItem');
+        expect(router.resolve('/categories/project/items')).toBe('categoryItems');
+      });
+
+      it('does not match a partial path', function() {
+        router.register('/categories', 'categories');
+
+        expect(router.resolve('/categories/extra')).toBe('home');
+      });
+    });
+  });
+
+  describe('class methods', function() {
+    beforeEach(function() {
+      Router.reset();
+    });
+
+    afterEach(function() {
+      Router.reset();
+    });
+
+    describe('.register and .resolve', function() {
+      it('resolves a registered route', function() {
+        Router.register('/categories', 'categories');
+
+        expect(Router.resolve('/categories')).toBe('categories');
+      });
+
+      it('creates the registry on first call', function() {
+        Router.register('/kinds', 'kinds');
+
+        expect(Router.resolve('/kinds')).toBe('kinds');
+      });
+
+      it('resolves a route with a slug param', function() {
+        Router.register('/categories/:slug/items', 'categoryItems');
+
+        expect(Router.resolve('/categories/project/items')).toBe('categoryItems');
+      });
+
+      it('returns "home" for unmatched routes', function() {
+        expect(Router.resolve('/unknown')).toBe('home');
+      });
+
+      it('delegates to a shared registry instance', function() {
+        Router.register('/categories', 'categories');
+        Router.register('/kinds', 'kinds');
+
+        expect(Router.resolve('/categories')).toBe('categories');
+        expect(Router.resolve('/kinds')).toBe('kinds');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Route resolution in `HashRouteResolver` was driven by a sequential series of hard-coded regexes, making it brittle and hard to extend. This introduces a `Router` class that centralizes route definitions via a declarative registration API, and a `Route` class that encapsulates the regex and page identifier for a single route.

## Route class (`utils/Route.js`)

- Encapsulates regex compilation and matching for a single route entry
- `:param` path segments compile to `[^/]+` regex fragments with optional trailing slash
- Exposes `matches(route)` and a `page` getter

## Router class (`utils/Router.js`)

- Class-level singleton registry, lazily created on first use
- Class methods (`register`, `resolve`, `reset`) delegate to the singleton instance
- Instance methods available for direct/isolated use (e.g. inside `HashRouteResolver`)
- Stores `Route` instances and delegates matching to them

```js
Router.register('/categories/:slug/items/:id', 'categoryItem');
Router.register('/categories/:slug/items', 'categoryItems');
Router.register('/categories', 'categories');
Router.register('/kinds', 'kinds');

Router.resolve('/categories/tech/items/42'); // → 'categoryItem'
Router.resolve('/categories');               // → 'categories'
Router.resolve('/unknown');                  // → 'home'
```

## HashRouteResolver refactor

- Builds a private `Router` instance via `#buildRouter()` — isolates route config from the global singleton, avoiding test cross-contamination
- `getPage()` now strips the `#` prefix and query string before resolving, so `#/categories?page=2` correctly matches `/categories`

## Tests

- `spec/utils/Route_spec.js`: covers exact matches, trailing slash, `:param` segments, multiple params, non-matching paths, and the `page` getter
- `spec/utils/Router_spec.js`: covers instance and class-level behavior: exact matches, trailing slash, `:param` segments, multiple params, registration order precedence, partial-path rejection, and fallback to `'home'`

Fixes #164 
