### PR TITLE
Add new category item page 

### DIFF
--- a/frontend/assets/js/client/GenericClient.js
+++ b/frontend/assets/js/client/GenericClient.js
@@ -55,6 +55,25 @@ export default class GenericClient {
   }
 
   /**
+   * Sends a POST request with JSON payload and returns the parsed JSON body.
+   *
+   * @param {string} path resource path
+   * @param {Object} body JSON payload body
+   * @returns {Promise<*>} parsed JSON response body
+   * @throws {Error} if the response is not ok
+   */
+  async post(path, body) {
+    return this.#request(path, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
    * Sends a PATCH request with JSON payload and returns the parsed JSON body.
    *
    * @param {string} path resource path

--- a/frontend/assets/js/components/helpers/AppHelper.jsx
+++ b/frontend/assets/js/components/helpers/AppHelper.jsx
@@ -3,6 +3,7 @@ import Header from '../elements/Header.jsx';
 import Categories from '../pages/Categories.jsx';
 import CategoryItem from '../pages/CategoryItem.jsx';
 import CategoryItemEdit from '../pages/CategoryItemEdit.jsx';
+import CategoryItemNew from '../pages/CategoryItemNew.jsx';
 import CategoryItems from '../pages/CategoryItems.jsx';
 import Kinds from '../pages/Kinds.jsx';
 
@@ -10,6 +11,7 @@ const PAGES = {
   categories: <Categories />,
   categoryItem: <CategoryItem />,
   categoryItemEdit: <CategoryItemEdit />,
+  categoryItemNew: <CategoryItemNew />,
   categoryItems: <CategoryItems />,
   home: <Categories />,
   kinds: <Kinds />,

--- a/frontend/assets/js/components/pages/CategoryItemNew.jsx
+++ b/frontend/assets/js/components/pages/CategoryItemNew.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useMemo, useState } from 'react';
+import CategoryItemNewController from './controllers/CategoryItemNewController.js';
+import CategoryItemEditHelper from './helpers/CategoryItemEditHelper.jsx';
+
+/**
+ * Page component that displays the category item creation form.
+ *
+ * @returns {JSX.Element} new item page with loading, error, or content state
+ */
+export default function CategoryItemNew() {
+  const [item, setItem] = useState(null);
+  const [kinds, setKinds] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const controller = useMemo(
+    () => new CategoryItemNewController(setItem, setKinds, setLoading, setSaving, setError),
+    []
+  );
+
+  useEffect(() => {
+    const effect = controller.buildEffect();
+
+    return effect();
+  }, [controller]);
+
+  if (loading) {
+    return CategoryItemEditHelper.renderLoading();
+  }
+
+  if (error) {
+    return CategoryItemEditHelper.renderError(error);
+  }
+
+  if (!item) {
+    return CategoryItemEditHelper.renderError('Unable to load category item new form.');
+  }
+
+  return CategoryItemEditHelper.render(
+    item,
+    kinds,
+    saving,
+    (field, value) => controller.onFieldChange(field, value),
+    (index, field, value) => controller.onLinkChange(index, field, value),
+    (index) => controller.onRemoveLink(index),
+    () => controller.onAddLink(),
+    () => controller.save(item),
+    controller.cancelHref(item)
+  );
+}

--- a/frontend/assets/js/components/pages/controllers/CategoryItemNewController.js
+++ b/frontend/assets/js/components/pages/controllers/CategoryItemNewController.js
@@ -1,0 +1,227 @@
+import GenericClient from '../../../client/GenericClient.js';
+import BasePageController from './BasePageController.js';
+import Router from '../../../utils/Router.js';
+
+/**
+ * Extracts category slug from a category item new hash route.
+ *
+ * @param {string} [hash=''] current location hash
+ * @returns {{slug: string}} route params or empty values when unresolved
+ */
+export function getCategoryItemNewParamsFromHash(hash = '') {
+  return {
+    slug: '',
+    ...Router.extractParams('/categories/:slug/items/new', hash),
+  };
+}
+
+/**
+ * Manages category item new page state and create flow.
+ */
+export default class CategoryItemNewController extends BasePageController {
+  /**
+   * Creates a new CategoryItemNewController instance.
+   *
+   * @param {Function} setItem state setter for item data
+   * @param {Function} setKinds state setter for kinds list
+   * @param {Function} setLoading state setter for loading status
+   * @param {Function} setSaving state setter for saving status
+   * @param {Function} setError state setter for error message
+   * @param {GenericClient|null} [client] optional client instance
+   * @param {Object|null} [locationTarget] optional location target used for redirects
+   */
+  constructor(setItem, setKinds, setLoading, setSaving, setError, client = null, locationTarget = null) {
+    super();
+    this.setItem = setItem;
+    this.setKinds = setKinds;
+    this.setLoading = setLoading;
+    this.setSaving = setSaving;
+    this.setError = setError;
+    this.client = client ?? new GenericClient();
+    this.locationTarget = locationTarget ?? (typeof window === 'undefined' ? { hash: '' } : window.location);
+  }
+
+  /**
+   * Builds the React effect that loads new item form data and kinds on mount.
+   *
+   * @returns {Function} effect function that starts loading and returns a cleanup function
+   */
+  buildEffect() {
+    return () => {
+      let mounted = true;
+      const safeSet = this.buildSafeSetter(() => mounted);
+      const { slug } = getCategoryItemNewParamsFromHash(this.client.currentHash());
+
+      this.#loadData(safeSet, slug);
+
+      return () => {
+        mounted = false;
+      };
+    };
+  }
+
+  /**
+   * Creates a new item and redirects to the category items index on success.
+   *
+   * @param {Object} item item state to submit
+   * @returns {Promise<void>} save promise
+   */
+  save(item) {
+    const { slug } = getCategoryItemNewParamsFromHash(this.client.currentHash());
+
+    if (!slug || !item) {
+      this.setError('Unable to save category item.');
+      return Promise.reject(new Error('Unable to save category item.'));
+    }
+
+    this.setSaving(true);
+    this.setError(null);
+
+    return this.client.post(`/categories/${slug}/items.json`, this.#buildPayload(item))
+      .then(() => this.#onSaveSuccess(slug))
+      .catch(() => this.#onSaveError())
+      .finally(() => this.#finalizeSave());
+  }
+
+  /**
+   * Updates a single field on the current item state.
+   *
+   * @param {string} field field name to update
+   * @param {string} value new field value
+   */
+  onFieldChange(field, value) {
+    this.setItem((current) => ({ ...current, [field]: value }));
+  }
+
+  /**
+   * Updates a field on a link at the given index.
+   *
+   * @param {number} index link index
+   * @param {string} field field name to update
+   * @param {string} value new field value
+   */
+  onLinkChange(index, field, value) {
+    this.setItem((current) => {
+      const links = [...(current.links || [])];
+      links[index] = { ...(links[index] || {}), [field]: value };
+      return { ...current, links };
+    });
+  }
+
+  /**
+   * Removes the link at the given index from the current item state.
+   *
+   * @param {number} index link index to remove
+   */
+  onRemoveLink(index) {
+    this.setItem((current) => {
+      const links = [...(current.links || [])];
+      links.splice(index, 1);
+      return { ...current, links };
+    });
+  }
+
+  /**
+   * Appends an empty link entry to the current item state.
+   */
+  onAddLink() {
+    this.setItem((current) => ({
+      ...current,
+      links: [...(current.links || []), { text: '', url: '' }],
+    }));
+  }
+
+  /**
+   * Returns the cancel/back href for the new item page.
+   *
+   * @param {Object} item current item state
+   * @returns {string} href pointing to the category items index
+   */
+  cancelHref(item) {
+    const slug = item?.category?.slug || '';
+    return `/#/categories/${slug}/items`;
+  }
+
+  #loadData(safeSet, slug) {
+    Promise.all([
+      this.#fetchItem(slug),
+      this.#fetchKinds(slug),
+    ])
+      .then(([item, kinds]) => this.#applyLoadedData(safeSet, item, kinds))
+      .catch((error) => this.#onLoadError(safeSet, error))
+      .finally(() => this.#finalizeLoad(safeSet));
+  }
+
+  #normalizeItem(item) {
+    return {
+      ...item,
+      kind_slug: item.kind_slug || item.kind?.slug || '',
+      links: Array.isArray(item.links) ? item.links : [],
+    };
+  }
+
+  #buildPayload(item) {
+    return {
+      item: {
+        name: item.name || '',
+        description: item.description || '',
+        kind_slug: item.kind_slug || '',
+        visible: item.visible,
+        links: this.#buildLinkPayload(item.links),
+      },
+    };
+  }
+
+  #applyLoadedData(safeSet, item, kinds) {
+    safeSet(this.setItem, this.#normalizeItem(item));
+    safeSet(this.setKinds, kinds);
+  }
+
+  #onSaveSuccess(slug) {
+    this.locationTarget.hash = `#/categories/${slug}/items`;
+  }
+
+  #onSaveError() {
+    this.setError('Unable to save category item.');
+  }
+
+  #finalizeSave() {
+    this.setSaving(false);
+  }
+
+  #onLoadError(safeSet, error) {
+    safeSet(this.setError, error?.message || 'Unable to load category item new form.');
+  }
+
+  #finalizeLoad(safeSet) {
+    safeSet(this.setLoading, false);
+  }
+
+  #buildLinkPayload(links) {
+    return (Array.isArray(links) ? links : []).map((link, index) => ({
+      id: link.id,
+      text: link.text || '',
+      url: link.url || '',
+      order: link.order ?? index + 1,
+    }));
+  }
+
+  #fetchItem(slug) {
+    if (!slug) {
+      return Promise.reject(new Error('Unable to load category item new form.'));
+    }
+
+    return this.client.fetch(`/categories/${slug}/items/new.json`)
+      .catch(() => { throw new Error('Unable to load category item new form.'); });
+  }
+
+  #fetchKinds(slug) {
+    if (!slug) {
+      return Promise.reject(new Error('Unable to load category item new form.'));
+    }
+
+    return this.client.fetch(`/categories/${slug}/kinds.json`)
+      .then((kinds) => (Array.isArray(kinds) ? kinds : []))
+      .catch(() => { throw new Error('Unable to load category item new form.'); });
+  }
+}

--- a/frontend/assets/js/components/pages/helpers/CategoryItemEditHelper.jsx
+++ b/frontend/assets/js/components/pages/helpers/CategoryItemEditHelper.jsx
@@ -40,6 +40,8 @@ export default class CategoryItemEditHelper {
    * @param {Function} onRemoveLink callback(index)
    * @param {Function} onAddLink callback()
    * @param {Function} onSave callback()
+   * @param {string|null} [cancelHref] optional href for the cancel/back button;
+   *   defaults to the item show page URL derived from item data
    * @returns {JSX.Element} category item edit content
    */
   static render(
@@ -50,11 +52,12 @@ export default class CategoryItemEditHelper {
     onLinkChange,
     onRemoveLink,
     onAddLink,
-    onSave
+    onSave,
+    cancelHref = null
   ) {
     return (
       <div className='container mt-4'>
-        {this.#renderActions(item, saving, onSave)}
+        {this.#renderActions(item, saving, onSave, cancelHref)}
         {this.#renderInfoCard(item, kinds, onFieldChange)}
 
         <CategoryItemLinksEditor
@@ -67,12 +70,13 @@ export default class CategoryItemEditHelper {
     );
   }
 
-  static #renderActions(item, saving, onSave) {
+  static #renderActions(item, saving, onSave, cancelHref = null) {
     const slug = item.category?.slug || '';
+    const href = cancelHref ?? `/#/categories/${slug}/items/${item.id}`;
 
     return (
       <div className='mb-3'>
-        <a className='btn btn-outline-secondary me-2' href={`/#/categories/${slug}/items/${item.id}`}>
+        <a className='btn btn-outline-secondary me-2' href={href}>
           Back
         </a>
         <button className='btn btn-success' disabled={saving} onClick={onSave} type='button'>

--- a/frontend/assets/js/utils/HashRouteResolver.js
+++ b/frontend/assets/js/utils/HashRouteResolver.js
@@ -18,6 +18,7 @@ export default class HashRouteResolver {
   static #buildRouter() {
     const router = new Router();
     router.register('/categories/:slug/items/:id/edit', 'categoryItemEdit');
+    router.register('/categories/:slug/items/new', 'categoryItemNew');
     router.register('/categories/:slug/items/:id', 'categoryItem');
     router.register('/categories/:slug/items', 'categoryItems');
     router.register('/categories', 'categories');

--- a/frontend/spec/client/GenericClient_spec.js
+++ b/frontend/spec/client/GenericClient_spec.js
@@ -131,6 +131,36 @@ describe('GenericClient', function() {
     });
   });
 
+  describe('#post', function() {
+    it('sends post request with json payload and returns parsed json', async function() {
+      stubJsonResponse({ id: 36, name: 'New Item' });
+
+      const client = new GenericClient(() => '');
+      const payload = { item: { name: 'New Item' } };
+      const result = await client.post('/categories/project/items.json', payload);
+
+      expect(result).toEqual({ id: 36, name: 'New Item' });
+      expect(global.fetch).toHaveBeenCalledWith('/categories/project/items.json', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+    });
+
+    it('throws on non-ok response', async function() {
+      stubFetchResponse({ ok: false, status: 422 });
+
+      const client = new GenericClient(() => '');
+
+      await expectAsync(
+        client.post('/categories/project/items.json', { item: { name: '' } })
+      ).toBeRejectedWithError('Request failed for /categories/project/items.json');
+    });
+  });
+
   describe('#patch', function() {
     it('sends patch request with json payload and returns parsed json', async function() {
       stubJsonResponse({ id: 35, name: 'Oak Updated' });

--- a/frontend/spec/components/helpers/AppHelper_spec.js
+++ b/frontend/spec/components/helpers/AppHelper_spec.js
@@ -59,6 +59,12 @@ describe('AppHelper', function() {
       expect(html).toContain('Loading category item edit...');
     });
 
+    it('renders the CategoryItemNew component for "categoryItemNew" page', function() {
+      const html = renderPage('categoryItemNew');
+
+      expect(html).toContain('Loading category item edit...');
+    });
+
     it('renders the Kinds component for "kinds" page', function() {
       const html = renderPage('kinds');
 

--- a/frontend/spec/components/pages/CategoryItemNew_spec.js
+++ b/frontend/spec/components/pages/CategoryItemNew_spec.js
@@ -1,0 +1,6 @@
+import CategoryItemNew from '../../../assets/js/components/pages/CategoryItemNew.jsx';
+import { itRendersPageLoadingState } from '../../support/shared_examples/pageExamples.js';
+
+describe('CategoryItemNew', function() {
+  itRendersPageLoadingState(CategoryItemNew, 'Loading category item edit...');
+});

--- a/frontend/spec/components/pages/controllers/CategoryItemNewController_spec.js
+++ b/frontend/spec/components/pages/controllers/CategoryItemNewController_spec.js
@@ -1,0 +1,261 @@
+import CategoryItemNewController, { getCategoryItemNewParamsFromHash } from '../../../../assets/js/components/pages/controllers/CategoryItemNewController.js';
+import {
+  buildSpies,
+  flushPromises,
+} from '../../../support/factories.js';
+
+describe('CategoryItemNewController', function() {
+  let mockClient;
+  let mockLocation;
+
+  const buildMockClient = (overrides = {}) => ({
+    currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/project/items/new'),
+    fetch: jasmine.createSpy('fetch').and.callFake((path) => {
+      if (path === '/categories/project/items/new.json') {
+        return Promise.resolve({
+          name: '',
+          description: '',
+          category: { slug: 'project', name: 'Project' },
+          kind: null,
+          links: [],
+        });
+      }
+
+      if (path === '/categories/project/kinds.json') {
+        return Promise.resolve([{ slug: 'code', name: 'Code' }]);
+      }
+
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    }),
+    post: jasmine.createSpy('post').and.returnValue(Promise.resolve({ id: 36 })),
+    ...overrides,
+  });
+
+  const buildSetters = () => buildSpies(
+    'setItem',
+    'setKinds',
+    'setLoading',
+    'setSaving',
+    'setError'
+  );
+
+  beforeEach(function() {
+    mockClient = buildMockClient();
+    mockLocation = { hash: '#/categories/project/items/new' };
+  });
+
+  describe('getCategoryItemNewParamsFromHash', function() {
+    it('extracts slug from new item hash route', function() {
+      const params = getCategoryItemNewParamsFromHash('#/categories/project/items/new');
+
+      expect(params).toEqual({ slug: 'project' });
+    });
+
+    it('returns empty slug when hash does not match the new route', function() {
+      const params = getCategoryItemNewParamsFromHash('#/categories/project/items/35');
+
+      expect(params).toEqual({ slug: '' });
+    });
+  });
+
+  it('loads new item form and kinds in buildEffect', async function() {
+    const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+    const controller = new CategoryItemNewController(
+      setItem,
+      setKinds,
+      setLoading,
+      setSaving,
+      setError,
+      mockClient,
+      mockLocation
+    );
+    const cleanup = controller.buildEffect()();
+
+    await flushPromises();
+
+    expect(mockClient.fetch).toHaveBeenCalledWith('/categories/project/items/new.json');
+    expect(mockClient.fetch).toHaveBeenCalledWith('/categories/project/kinds.json');
+    expect(setItem).toHaveBeenCalledWith(jasmine.objectContaining({
+      name: '',
+      kind_slug: '',
+      links: [],
+    }));
+    expect(setKinds).toHaveBeenCalledWith([{ slug: 'code', name: 'Code' }]);
+    expect(setLoading).toHaveBeenCalledWith(false);
+    expect(setError).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('sets error when loading fails', async function() {
+    const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+    mockClient = buildMockClient({
+      fetch: jasmine.createSpy('fetch').and.returnValue(Promise.reject(new Error('boom'))),
+    });
+    const controller = new CategoryItemNewController(
+      setItem,
+      setKinds,
+      setLoading,
+      setSaving,
+      setError,
+      mockClient,
+      mockLocation
+    );
+    const cleanup = controller.buildEffect()();
+
+    await flushPromises();
+
+    expect(setError).toHaveBeenCalledWith('Unable to load category item new form.');
+    expect(setLoading).toHaveBeenCalledWith(false);
+
+    cleanup();
+  });
+
+  it('posts payload and redirects to items index page', async function() {
+    const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+    const controller = new CategoryItemNewController(
+      setItem,
+      setKinds,
+      setLoading,
+      setSaving,
+      setError,
+      mockClient,
+      mockLocation
+    );
+
+    await controller.save({
+      name: 'New Oak',
+      description: 'A new project item',
+      kind_slug: 'code',
+      visible: true,
+      links: [{ id: undefined, text: 'GitHub', url: 'https://github.com/darthjee/oak' }],
+    });
+
+    expect(mockClient.post).toHaveBeenCalledWith('/categories/project/items.json', {
+      item: {
+        name: 'New Oak',
+        description: 'A new project item',
+        kind_slug: 'code',
+        visible: true,
+        links: [{ id: undefined, text: 'GitHub', url: 'https://github.com/darthjee/oak', order: 1 }],
+      },
+    });
+    expect(mockLocation.hash).toBe('#/categories/project/items');
+    expect(setSaving).toHaveBeenCalledWith(true);
+    expect(setSaving).toHaveBeenCalledWith(false);
+    expect(setError).toHaveBeenCalledWith(null);
+  });
+
+  it('sets error when save fails', async function() {
+    const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+    mockClient = buildMockClient({
+      post: jasmine.createSpy('post').and.returnValue(Promise.reject(new Error('boom'))),
+    });
+    const controller = new CategoryItemNewController(
+      setItem,
+      setKinds,
+      setLoading,
+      setSaving,
+      setError,
+      mockClient,
+      mockLocation
+    );
+
+    await controller.save({
+      name: 'New Oak',
+      description: 'A new project item',
+      kind_slug: 'code',
+      links: [],
+    });
+
+    expect(setError).toHaveBeenCalledWith('Unable to save category item.');
+    expect(setSaving).toHaveBeenCalledWith(false);
+  });
+
+  describe('#onFieldChange', function() {
+    it('updates the specified field on the item', function() {
+      const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+      const controller = new CategoryItemNewController(
+        setItem, setKinds, setLoading, setSaving, setError, mockClient, mockLocation
+      );
+
+      controller.onFieldChange('name', 'Updated Name');
+
+      const updater = setItem.calls.mostRecent().args[0];
+
+      expect(updater({ name: 'Old', links: [] })).toEqual({ name: 'Updated Name', links: [] });
+    });
+  });
+
+  describe('#onLinkChange', function() {
+    it('updates the specified field on a link at the given index', function() {
+      const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+      const controller = new CategoryItemNewController(
+        setItem, setKinds, setLoading, setSaving, setError, mockClient, mockLocation
+      );
+
+      controller.onLinkChange(0, 'text', 'GitHub');
+
+      const updater = setItem.calls.mostRecent().args[0];
+
+      expect(updater({ links: [{ text: '', url: 'https://github.com' }] })).toEqual({
+        links: [{ text: 'GitHub', url: 'https://github.com' }],
+      });
+    });
+  });
+
+  describe('#onRemoveLink', function() {
+    it('removes the link at the given index', function() {
+      const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+      const controller = new CategoryItemNewController(
+        setItem, setKinds, setLoading, setSaving, setError, mockClient, mockLocation
+      );
+
+      controller.onRemoveLink(0);
+
+      const updater = setItem.calls.mostRecent().args[0];
+
+      expect(updater({ links: [{ text: 'A' }, { text: 'B' }] })).toEqual({
+        links: [{ text: 'B' }],
+      });
+    });
+  });
+
+  describe('#onAddLink', function() {
+    it('appends an empty link to the item links', function() {
+      const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+      const controller = new CategoryItemNewController(
+        setItem, setKinds, setLoading, setSaving, setError, mockClient, mockLocation
+      );
+
+      controller.onAddLink();
+
+      const updater = setItem.calls.mostRecent().args[0];
+
+      expect(updater({ links: [] })).toEqual({
+        links: [{ text: '', url: '' }],
+      });
+    });
+  });
+
+  describe('#cancelHref', function() {
+    it('returns the items index href for the item category slug', function() {
+      const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+      const controller = new CategoryItemNewController(
+        setItem, setKinds, setLoading, setSaving, setError, mockClient, mockLocation
+      );
+      const item = { category: { slug: 'project' } };
+
+      expect(controller.cancelHref(item)).toBe('/#/categories/project/items');
+    });
+
+    it('returns a fallback href when category slug is absent', function() {
+      const { setItem, setKinds, setLoading, setSaving, setError } = buildSetters();
+      const controller = new CategoryItemNewController(
+        setItem, setKinds, setLoading, setSaving, setError, mockClient, mockLocation
+      );
+
+      expect(controller.cancelHref({})).toBe('/#/categories//items');
+    });
+  });
+});

--- a/frontend/spec/utils/HashRouteResolver_spec.js
+++ b/frontend/spec/utils/HashRouteResolver_spec.js
@@ -34,6 +34,12 @@ describe('HashRouteResolver', function() {
       expect(resolver.getPage()).toBe('categoryItemEdit');
     });
 
+    it('returns "categoryItemNew" for category item new routes', function() {
+      const resolver = new HashRouteResolver(() => '#/categories/project/items/new');
+
+      expect(resolver.getPage()).toBe('categoryItemNew');
+    });
+
     it('returns "categoryItem" for category item routes', function() {
       const resolver = new HashRouteResolver(() => '#/categories/project/items/35');
 


### PR DESCRIPTION
Adds a `/#/categories/:slug/items/new` frontend route that lets users create new category items. The form is visually identical to the edit page, loads initial data from `GET /categories/:slug/items/new.json`, and saves via `POST /categories/:slug/items`. On success it redirects to the items index with no query params preserved.

## Approach
- Extracted a `cancelHref` param (optional, backward-compatible) from `CategoryItemEditHelper.render()` so both pages can reuse the same helper — the new page passes `/#/categories/:slug/items`, edit retains its default item-show URL.
- **`CategoryItemNewController`** mirrors `CategoryItemEditController` but uses `fetch(.../new.json)` on load and `client.post(...)` on save, redirecting to the items index.
- **`CategoryItemNew`** page component is a thin wrapper over `CategoryItemNewController` + the shared helper.
- Route `/categories/:slug/items/new` is registered in `HashRouteResolver` **before** `/categories/:slug/items/:id` so the literal segment `new` is not swallowed by the `:id` param capture.
- Added `post()` to `GenericClient` alongside the existing `patch()`.

## Files changed
- `GenericClient.js` — new `post()` method
- `CategoryItemEditHelper.jsx` — optional `cancelHref` param on `render()`
- `CategoryItemNewController.js` *(new)* — create-flow controller
- `CategoryItemNew.jsx` *(new)* — page component
- `HashRouteResolver.js` — route registration order + new route
- `AppHelper.jsx` — `categoryItemNew` entry in page map

Fixes #170 