### PR TITLE
Hide category field from category item new/edit form

### DIFF
--- a/frontend/assets/js/components/pages/helpers/CategoryItemEditHelper.jsx
+++ b/frontend/assets/js/components/pages/helpers/CategoryItemEditHelper.jsx
@@ -95,12 +95,6 @@ export default class CategoryItemEditHelper {
           value={item.name || ''}
           onChange={this.#buildFieldChangeHandler(onFieldChange, 'name')}
         />
-        <LabeledInput
-          id='category-item-edit-category'
-          label='Category'
-          readOnly
-          value={item.category?.name || ''}
-        />
         <CategoryItemKindSelect
           kinds={kinds}
           onChange={this.#buildFieldChangeHandler(onFieldChange, 'kind_slug')}

--- a/frontend/spec/components/pages/helpers/CategoryItemEditHelper_spec.js
+++ b/frontend/spec/components/pages/helpers/CategoryItemEditHelper_spec.js
@@ -32,7 +32,7 @@ describe('CategoryItemEditHelper', function() {
     expect(html).toContain('/#/categories/project/items/35');
     expect(html).toContain('Save');
     expect(html).toContain('Name');
-    expect(html).toContain('Category');
+    expect(html).not.toContain('Category');
     expect(html).toContain('Kind');
     expect(html).toContain('Description');
     expect(html).toContain('Code');


### PR DESCRIPTION
Category was being rendered in category item form routes (new/edit), even though category context already comes from the route slug. This change removes category from form rendering while keeping it visible on the item show page.

- **Form UI update (new/edit routes)**
  - Removed the read-only `Category` `LabeledInput` from `CategoryItemEditHelper.#renderInfoCard`.
  - Keeps the form focused on editable fields (`Name`, `Kind`, `Description`, links).

- **Spec alignment**
  - Updated `CategoryItemEditHelper_spec` to assert `Category` is **not** present in form output.
  - Existing show-page helper remains unchanged, so category display on show is preserved.

```jsx
// CategoryItemEditHelper.#renderInfoCard (after)
<CategoryItemInfoCard name={item.name || 'Edit Item'}>
  <LabeledInput id='category-item-edit-name' label='Name' ... />
  <CategoryItemKindSelect kinds={kinds} ... />
  <LabeledInput id='category-item-edit-description' label='Description' ... />
</CategoryItemInfoCard>
```

Fixes #175 