### PR TITLE
Refresh `docs/agents` frontend docs for current React + Vite architecture

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Oak is a Rails monolithic application that serves both the frontend and the JSON API from the same process. The frontend is a Single Page Application (SPA) built with **AngularJS** and styled with **Bootstrap**. All Rails code lives under `source/`.
+Oak is a Rails monolithic application that serves JSON endpoints and the SPA shell from the same process. The frontend is a Single Page Application (SPA) built with **React** + **Vite** in `frontend/`, styled with **Bootstrap**, and mounted into `frontend/index.html` via `frontend/assets/js/main.jsx`. All Rails code lives under `source/`.
 
 In development and production a reverse proxy (**darthjee/tent**) sits in front of the Rails app to cache HTML responses and simulate the production setup. In development the proxy runs as the `oak_proxy` Docker service (port 3000); in production the same proxy binary runs natively (without Docker).
 
@@ -30,14 +30,13 @@ In production there is no `oak_photos` container; uploaded files are served by t
 
 ## Request Routing
 
-Every HTTP request to the Rails app follows one of four paths:
+Frontend-serving requests follow one of these paths:
 
 | Pattern | Behaviour |
 |---------|-----------|
-| `GET /` | Renders the home page (layout + full HTML). Handled by `HomeController`. |
-| `GET /<path>` (HTML, no `?ajax`) | Redirected to `/#/<path>` by the `OnePageApplication` concern so AngularJS takes over navigation. No data is fetched. |
-| `GET /<path>?ajax=true` | Returns the ERB template for that route **without the application layout**. AngularJS (via Cyberhawk) fetches this to render the view. |
-| `GET /<path>.json` | Returns the JSON payload for that route via Azeroth decorators. AngularJS fetches this for the data. |
+| `GET /` | Serves the SPA shell (`index.html`) handled by `HomeController`, which boots the React app. |
+| `GET /<path>` (HTML) | Redirected to `/#/<path>` by the `OnePageApplication` concern so client-side hash routing takes over navigation. |
+| `GET /<path>.json` | Returns JSON payloads for frontend data loading via Azeroth decorators. |
 
 The redirect logic lives in `app/controllers/concerns/one_page_application.rb`, which uses the **Tarquinn** gem. Controllers include `OnePageApplication` to opt in to SPA behaviour.
 
@@ -45,10 +44,14 @@ The redirect logic lives in `app/controllers/concerns/one_page_application.rb`, 
 
 ## Frontend
 
-- **AngularJS** — handles client-side routing via URL anchors (`#/<path>`).
-- **Cyberhawk** (<https://github.com/darthjee/cyberhawk>) — manages the request lifecycle: intercepts anchor navigation, fetches `?ajax=true` templates and `.json` data, then renders the page.
+- **React + Vite** — client-side application and build/dev tooling (`frontend/`, `vite.config.js`).
+- **Hash-based routing utilities** — `AppController` + `HashRouteResolver` + `Router`/`Route` resolve `#/<path>` URLs and route params.
+- **React Query** — mounted in `main.jsx` through `QueryClientProvider` for async state/query lifecycle.
 - **Bootstrap** — CSS framework used in all ERB templates.
-- Routes are defined with anchors; no full page reloads happen after the initial load.
+- Routes are anchor-based (`#/<path>`); after initial load, navigation stays in the SPA shell.
+- **Tent proxy** serves frontend differently by mode:
+  - `FRONTEND_DEV_MODE=true`: proxies `/`, `/assets/js/`, `/assets/css/`, `/assets/images/`, `/@vite/`, `/node_modules/`, and `/@react-refresh` to `http://frontend:8080` (Vite + HMR).
+  - `FRONTEND_DEV_MODE=false`: serves static files from `/var/www/html/static`; `/` is rewritten to `/index.html`.
 
 ---
 
@@ -75,7 +78,7 @@ The redirect logic lives in `app/controllers/concerns/one_page_application.rb`, 
 | Gem | Role |
 |-----|------|
 | **[Azeroth](https://github.com/darthjee/azeroth)** | Generates standard CRUD controller actions and JSON serialization via decorators. See [azeroth-usage.md](azeroth-usage.md). |
-| **[Magicka](https://github.com/darthjee/magicka)** | Renders AngularJS-compatible form and display elements inside ERB templates. See [magicka-usage.md](magicka-usage.md). |
+| **[Magicka](https://github.com/darthjee/magicka)** | Renders reusable form/display elements in ERB templates. See [magicka-usage.md](magicka-usage.md). |
 | **[Sinclair](https://github.com/darthjee/sinclair)** | Dynamic method builder; also used for configuration (`Sinclair::Configurable`), option objects, and plain models. See [sinclair-usage.md](sinclair-usage.md). |
 | **[Tarquinn](https://github.com/darthjee/tarquinn)** | Declarative controller-level redirection rules (powers the SPA redirect). See [tarquinn-usage.md](tarquinn-usage.md). |
 | **[Jace](https://github.com/darthjee/jace)** | Internal event/lifecycle hooks for service operations. See [jace-usage.md](jace-usage.md). |
@@ -95,4 +98,4 @@ show.html.erb  → magicka_display → renders _form.html.erb
 
 `_form.html.erb` uses `form.only(:form)` / `form.only(:display)` to conditionally render editable vs. read-only elements in the same partial.
 
-When `?ajax=true` is present, the layout is suppressed and only the template fragment is returned so Cyberhawk can inject it into the SPA shell.
+Frontend SPA pages are rendered in React. Rails views remain in use for server-rendered pages/partials and form/display templates.

--- a/docs/agents/flow.md
+++ b/docs/agents/flow.md
@@ -6,28 +6,26 @@ A user can arrive at the application through three entry points:
 
 | Entry point | What happens |
 |-------------|--------------|
-| `GET /` | Rails renders the SPA shell: the full HTML page with the application layout, loading all JS and CSS assets. AngularJS boots and takes over. |
+| `GET /` | Rails serves the SPA shell (`index.html`) with frontend assets. React boots and takes over. |
 | `GET /<path>` | Rails (via `OnePageApplication` + Tarquinn) redirects the browser to `/#/<path>`. No content is rendered directly. |
-| `/#/<path>` directly | The browser already has the SPA shell. AngularJS/Cyberhawk intercepts the anchor and loads the page content (see below). |
+| `/#/<path>` directly | The browser already has the SPA shell. React route resolution picks the page from the hash path. |
 
 ---
 
 ## SPA Page Load
 
-Once the browser is on any `/#/<path>` — including `/#/` — Cyberhawk makes two parallel requests to populate the page:
+Once the browser is on any `/#/<path>` — including `/#/` — React resolves the hash route and the page controller fetches JSON data as needed:
 
 ```
 Browser on /#/<path>
         │
-        ├── GET /<path>?ajax=true  →  Rails returns the ERB template fragment (no layout)
-        │                                        (cached by darthjee/tent proxy)
         └── GET /<path>.json       →  Rails returns the JSON data for that resource
                 │
                 ▼
-        AngularJS merges template + data and renders the page
+        React renders/updates the page
 ```
 
-The proxy (**darthjee/tent**) caches the `?ajax=true` HTML responses, so repeated visits to the same page are served from cache without hitting Rails.
+When `FRONTEND_DEV_MODE=true`, Tent proxies frontend assets and Vite endpoints to `frontend:8080`. When disabled, Tent serves built static files from `/var/www/html/static`.
 
 ---
 
@@ -42,7 +40,7 @@ Some routes exist to support the application but are **not SPA resources** — t
 | `GET /users/login/check` | Checks whether the current session is valid. |
 | `GET /forbidden` | Returns `403 Forbidden` (used for authorization redirects). |
 
-These are called by AngularJS directly (e.g., on form submit) and their responses are handled in JS, not by rendering a new page.
+These are called by frontend clients/controllers directly (e.g., on form submit) and their responses are handled in JS, not by rendering a new page.
 
 ---
 
@@ -58,20 +56,18 @@ Browser loads /#/categories
   → GET /            (if shell not yet loaded)
       Rails renders full layout + JS/CSS assets
 
-Cyberhawk intercepts /#/categories:
-  → GET /categories?ajax=true            → template fragment (possibly from proxy cache)
+React resolves /#/categories:
   → GET /categories.json                 → JSON data
-  AngularJS renders the categories list
+  React renders the categories list
 ```
 
 ### User clicks a link inside the SPA (e.g., to `/categories/electronics`)
 
 ```
-AngularJS updates the anchor to /#/categories/electronics
+The frontend updates the anchor to /#/categories/electronics
 
-Cyberhawk intercepts:
-  → GET /categories/electronics?ajax=true  → template fragment
+React route resolver handles:
   → GET /categories/electronics.json       → JSON data
-  AngularJS renders the category detail page
+  React renders the category detail page
   (no full page reload)
 ```

--- a/docs/agents/frontend.md
+++ b/docs/agents/frontend.md
@@ -1,8 +1,18 @@
 # Front-End Architecture
 
-The Oak front-end is a React + Vite SPA located in `frontend/`. It runs in its own Docker container (`oak_fe`) and is served by the tent proxy.
+The Oak front-end is a React + Vite SPA located in `frontend/`. It runs in its own Docker container (`oak_fe`) and is served through the Tent proxy.
 
 Reference implementations: `../navi/frontend/src/components/` (component pattern) and `../weave/frontend/` (build/tooling setup).
+
+---
+
+## Runtime Boot Flow
+
+The SPA boot sequence is:
+
+1. `frontend/index.html` defines `<div id="root"></div>` and loads `/assets/js/main.jsx`.
+2. `frontend/assets/js/main.jsx` imports Bootstrap CSS/JS plus local CSS/SCSS, creates a `QueryClient`, and mounts `<App />` inside `QueryClientProvider`.
+3. `frontend/assets/js/components/App.jsx` uses `AppController` to resolve the current hash route and render the matching page.
 
 ---
 
@@ -202,14 +212,34 @@ Controlled by `FRONTEND_DEV_MODE` in `.env`:
 
 | Mode | Behaviour |
 |------|-----------|
-| `FRONTEND_DEV_MODE=true` | Tent proxies all front-end requests to the Vite dev server. HMR works. No caching. |
-| `FRONTEND_DEV_MODE=false` | Tent serves pre-built static files from `docker_volumes/static/`. |
+| `FRONTEND_DEV_MODE=true` | Tent proxies `GET /`, `/assets/js/`, `/assets/css/`, `/assets/images/`, `/@vite/`, `/node_modules/`, and `/@react-refresh` to `http://frontend:8080` (Vite dev server with HMR). |
+| `FRONTEND_DEV_MODE=false` | Tent serves static files from `/var/www/html/static`; `GET /` is rewritten to `/index.html`. |
 
 ---
 
-## Inline Documentation
+## Routing Utilities
 
-All public classes, methods, and exported functions in `frontend/assets/js/` must have JSDoc comments. ESLint enforces this via `eslint-plugin-jsdoc` (rules run as part of `npm run lint`).
+Routing helpers live under `frontend/assets/js/utils/`:
+
+- `Router.register(path, page)` registers route patterns.
+- `Router.resolve(route)` resolves a route path into a page key.
+- `Router.extractParams(path, route)` extracts params for `:param` segments.
+- `Route` compiles `:param` path segments into regex capture groups and exposes parsed params.
+
+`HashRouteResolver` builds the known route table and resolves the current `window.location.hash`, stripping query strings before route matching.
+
+---
+
+## Linting and Inline Documentation
+
+ESLint (`frontend/eslint.config.mjs`) enforces:
+
+- JSDoc for public classes/methods/functions in JS/JSX.
+- React + React Hooks rules (`react-hooks/rules-of-hooks` and `react-hooks/exhaustive-deps`).
+- Complexity/size constraints (`complexity`, `max-lines`, `max-depth`).
+- Jasmine-specific exceptions under `spec/` (JSDoc requirements are disabled for test files).
+
+All public classes, methods, and exported functions in `frontend/assets/js/` should include JSDoc comments.
 
 ### Convention
 

--- a/docs/agents/routes.md
+++ b/docs/agents/routes.md
@@ -1,12 +1,12 @@
 # Routes
 
-Routes fall into two categories: **resource routes** that are full SPA pages (redirect + `?ajax=true` template + `.json` data), and **utility routes** that are pure API endpoints called by AngularJS in the background (no template, no redirect).
+Routes fall into two categories: **resource routes** used by SPA pages (HTML redirect + `.json` data endpoints), and **utility routes** that are pure API endpoints called by the frontend in the background (no HTML template flow).
 
 ---
 
 ## Resource Routes
 
-These routes participate in the full SPA flow. An HTML GET request redirects to `/#/<path>`; AngularJS then fetches `/<path>?ajax=true` for the template and `/<path>.json` for the data.
+These routes participate in the SPA flow. An HTML GET request redirects to `/#/<path>`; the React frontend then fetches `/<path>.json` for data loading.
 
 All resource controllers include `OnePageApplication` (directly or via `UserRequired`).
 
@@ -73,7 +73,7 @@ Full user management, restricted to admins.
 
 ## Utility Routes
 
-These routes are **API-only**: they return JSON (or perform an action) and have no `?ajax=true` template. They are called directly by AngularJS — never navigated to as pages.
+These routes are **API-only**: they return JSON (or perform an action) and are called directly by frontend clients/controllers — never navigated to as pages.
 
 ### Session
 


### PR DESCRIPTION
`docs/agents` still described an AngularJS/Cyberhawk frontend model that no longer matches Oak. This PR updates frontend-facing agent docs to reflect the current React + Vite SPA, hash-routing utilities, and Tent’s dev/prod serving behavior.

- **Architecture doc alignment (`docs/agents/architecture.md`)**
  - Replaced AngularJS/Cyberhawk overview with current React + Vite SPA model.
  - Updated frontend request-routing section to reflect hash redirect + `.json` data flow.
  - Added Tent behavior by `FRONTEND_DEV_MODE` (dev proxy targets vs static serving + `/index.html` rewrite).
  - Updated frontend stack notes to include React Query mount context.

- **Frontend implementation guide refresh (`docs/agents/frontend.md`)**
  - Added explicit runtime boot flow from `frontend/index.html` to `assets/js/main.jsx` to `App`.
  - Documented Bootstrap + local styles imports and `QueryClientProvider` usage at app mount.
  - Expanded routing section with `Router.register`, `Router.resolve`, `Router.extractParams`, and `Route` `:param` behavior.
  - Clarified lint/JSDoc expectations from `frontend/eslint.config.mjs` (hooks, complexity, Jasmine exceptions).

- **Cross-doc consistency fixes (`docs/agents/flow.md`, `docs/agents/routes.md`)**
  - Removed stale AngularJS/Cyberhawk + `?ajax=true` template flow language.
  - Reworded SPA flow to match current React hash-route resolution and JSON-driven page loading.

```jsx
// frontend/assets/js/main.jsx
createRoot(document.getElementById('root')).render(
  <QueryClientProvider client={queryClient}>
    <App />
  </QueryClientProvider>
);
```