### PR TITLE
Add category show page in new frontend (`/#/categories/:slug`)

### DIFF
--- a/frontend/assets/js/components/elements/CategoryKinds.jsx
+++ b/frontend/assets/js/components/elements/CategoryKinds.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import CategoryKindsHelper from './helpers/CategoryKindsHelper.jsx';
+
+/**
+ * Renders category kinds as badges or an empty state message.
+ *
+ * @param {Object} props component props
+ * @param {Array} props.kinds category kinds
+ * @returns {JSX.Element} rendered kinds
+ */
+export default function CategoryKinds({ kinds }) {
+  if (!kinds || kinds.length === 0) {
+    return <p className='mb-0'>No kinds connected.</p>;
+  }
+
+  return (
+    <>
+      <p className='mb-2'>Kinds</p>
+      <div className='d-flex flex-wrap'>
+        {kinds.map((kind) => CategoryKindsHelper.renderKindBadge(kind))}
+      </div>
+    </>
+  );
+}

--- a/frontend/assets/js/components/elements/helpers/CategoryKindsHelper.jsx
+++ b/frontend/assets/js/components/elements/helpers/CategoryKindsHelper.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+/**
+ * Builds category kinds UI fragments.
+ */
+export default class CategoryKindsHelper {
+  /**
+   * Renders a category kind badge.
+   *
+   * @param {Object} kind category kind data
+   * @returns {JSX.Element} rendered badge
+   */
+  static renderKindBadge(kind) {
+    return (
+      <span key={kind.slug} className='badge text-bg-primary me-2 mb-2'>
+        {kind.name}
+      </span>
+    );
+  }
+}

--- a/frontend/assets/js/components/helpers/AppHelper.jsx
+++ b/frontend/assets/js/components/helpers/AppHelper.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Header from '../elements/Header.jsx';
+import Category from '../pages/Category.jsx';
 import Categories from '../pages/Categories.jsx';
 import CategoryItem from '../pages/CategoryItem.jsx';
 import CategoryItemEdit from '../pages/CategoryItemEdit.jsx';
@@ -8,6 +9,7 @@ import CategoryItems from '../pages/CategoryItems.jsx';
 import Kinds from '../pages/Kinds.jsx';
 
 const PAGES = {
+  category: <Category />,
   categories: <Categories />,
   categoryItem: <CategoryItem />,
   categoryItemEdit: <CategoryItemEdit />,

--- a/frontend/assets/js/components/pages/Category.jsx
+++ b/frontend/assets/js/components/pages/Category.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from 'react';
+import CategoryController from './controllers/CategoryController.js';
+import CategoryHelper from './helpers/CategoryHelper.jsx';
+
+/**
+ * Page component that displays a category details page.
+ *
+ * @returns {JSX.Element} category page with loading, error, or content state
+ */
+export default function Category() {
+  const [category, setCategory] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const controller = useMemo(
+    () => new CategoryController(setCategory, setLoading, setError),
+    []
+  );
+
+  useEffect(() => {
+    const effect = controller.buildEffect();
+
+    return effect();
+  }, [controller]);
+
+  if (loading) {
+    return CategoryHelper.renderLoading();
+  }
+
+  if (error) {
+    return CategoryHelper.renderError(error);
+  }
+
+  return CategoryHelper.render(category);
+}

--- a/frontend/assets/js/components/pages/controllers/CategoryController.js
+++ b/frontend/assets/js/components/pages/controllers/CategoryController.js
@@ -1,0 +1,97 @@
+import GenericClient from '../../../client/GenericClient.js';
+import BasePageController from './BasePageController.js';
+import Router from '../../../utils/Router.js';
+
+/**
+ * Extracts category slug from a category hash route.
+ *
+ * @param {string} [hash=''] current location hash
+ * @returns {string} category slug or an empty string when it cannot be resolved
+ */
+export function getCategorySlugFromHash(hash = '') {
+  return Router.extractParams('/categories/:slug', hash).slug || '';
+}
+
+/**
+ * Manages category page state by fetching category data from the API.
+ */
+export default class CategoryController extends BasePageController {
+  /**
+   * Creates a new CategoryController instance.
+   *
+   * @param {Function} setCategory state setter for category data
+   * @param {Function} setLoading state setter for loading status
+   * @param {Function} setError state setter for error message
+   * @param {GenericClient|null} [client] optional client instance
+   */
+  constructor(setCategory, setLoading, setError, client = null) {
+    super();
+    this.setCategory = setCategory;
+    this.setLoading = setLoading;
+    this.setError = setError;
+    this.client = client ?? new GenericClient();
+  }
+
+  /**
+   * Builds the React effect that loads category data on mount.
+   *
+   * @returns {Function} effect function that starts loading and returns a cleanup function
+   */
+  buildEffect() {
+    return () => {
+      let mounted = true;
+      const safeSet = this.buildSafeSetter(() => mounted);
+      const slug = getCategorySlugFromHash(this.client.currentHash());
+
+      this.#loadData(safeSet, slug);
+
+      return () => {
+        mounted = false;
+      };
+    };
+  }
+
+  #loadData(safeSet, slug) {
+    this.#fetchCategory(slug)
+      .then(this.#setCategoryState.bind(this, safeSet))
+      .catch(this.#setErrorState.bind(this, safeSet))
+      .finally(this.#setLoadingState.bind(this, safeSet));
+  }
+
+  #setCategoryState(safeSet, category) {
+    safeSet(this.setCategory, category);
+  }
+
+  #setErrorState(safeSet, error) {
+    safeSet(this.setError, error?.message || 'Unable to load category.');
+  }
+
+  #setLoadingState(safeSet) {
+    safeSet(this.setLoading, false);
+  }
+
+  #fetchCategory(slug) {
+    if (!slug) {
+      return Promise.reject(CategoryController.#buildLoadError());
+    }
+
+    return this.client.fetch(`/categories/${slug}.json`)
+      .then(CategoryController.#normalizeCategory)
+      .catch(CategoryController.#raiseLoadError);
+  }
+
+  static #normalizeCategory(category) {
+    return {
+      ...category,
+      kinds: Array.isArray(category.kinds) ? category.kinds : [],
+    };
+  }
+
+  static #raiseLoadError() {
+    throw CategoryController.#buildLoadError();
+  }
+
+  static #buildLoadError() {
+    return new Error('Unable to load category.');
+  }
+}

--- a/frontend/assets/js/components/pages/helpers/CategoriesHelper.jsx
+++ b/frontend/assets/js/components/pages/helpers/CategoriesHelper.jsx
@@ -71,7 +71,7 @@ export default class CategoriesHelper {
     return (
       <CatalogCard
         key={slug}
-        href={`/#/categories/${slug}/items`}
+        href={`/#/categories/${slug}`}
         title={name}
         imageSrc={snapUrl}
       />

--- a/frontend/assets/js/components/pages/helpers/CategoryHelper.jsx
+++ b/frontend/assets/js/components/pages/helpers/CategoryHelper.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import CategoryItemInfoCard from '../../elements/CategoryItemInfoCard.jsx';
+import CategoryKinds from '../../elements/CategoryKinds.jsx';
+import ErrorContainer from '../../elements/ErrorContainer.jsx';
+import LoadingMessage from '../../elements/LoadingMessage.jsx';
+import OptionalImage from '../../elements/OptionalImage.jsx';
+import PageActionsHelper from './PageActionsHelper.jsx';
+
+/**
+ * Renders the category page HTML for different states.
+ */
+export default class CategoryHelper {
+  /**
+   * Renders the category page in a loading state.
+   *
+   * @returns {JSX.Element} loading placeholder
+   */
+  static renderLoading() {
+    return <LoadingMessage message='Loading category...' />;
+  }
+
+  /**
+   * Renders the category page in an error state.
+   *
+   * @param {string} error error message to display
+   * @returns {JSX.Element} error alert container
+   */
+  static renderError(error) {
+    return <ErrorContainer error={error} />;
+  }
+
+  /**
+   * Renders the fully populated category page.
+   *
+   * @param {Object} category category data
+   * @returns {JSX.Element} category content
+   */
+  static render(category) {
+    return (
+      <div className='container mt-4'>
+        {this.#renderActions(category)}
+        <CategoryItemInfoCard name={category.name}>
+          <OptionalImage
+            src={category.snap_url}
+            alt={category.name}
+            className='img-fluid rounded mb-3'
+          />
+          <CategoryKinds kinds={category.kinds} />
+        </CategoryItemInfoCard>
+      </div>
+    );
+  }
+
+  static #renderActions(category) {
+    return PageActionsHelper.render(
+      '/#/categories',
+      `/#/categories/${category.slug}/items`,
+      'Items'
+    );
+  }
+}

--- a/frontend/assets/js/components/pages/helpers/CategoryItemHelper.jsx
+++ b/frontend/assets/js/components/pages/helpers/CategoryItemHelper.jsx
@@ -5,6 +5,7 @@ import ErrorContainer from '../../elements/ErrorContainer.jsx';
 import LabelValueParagraph from '../../elements/LabelValueParagraph.jsx';
 import LoadingMessage from '../../elements/LoadingMessage.jsx';
 import PhotosCarousel from '../../elements/PhotosCarousel.jsx';
+import PageActionsHelper from './PageActionsHelper.jsx';
 
 /**
  * Renders the category item page HTML for different states.
@@ -49,23 +50,9 @@ export default class CategoryItemHelper {
 
   static #renderActions(item, id, logged) {
     const slug = item.category?.slug || '';
+    const actionHref = logged ? `/#/categories/${slug}/items/${id}/edit` : null;
 
-    return (
-      <div className='mb-3'>
-        <a className='btn btn-outline-secondary me-2' href={`/#/categories/${slug}/items`}>
-          Back
-        </a>
-        {logged ? this.#renderEditButton(slug, id) : null}
-      </div>
-    );
-  }
-
-  static #renderEditButton(slug, id) {
-    return (
-      <a className='btn btn-primary' href={`/#/categories/${slug}/items/${id}/edit`}>
-        Edit
-      </a>
-    );
+    return PageActionsHelper.render(`/#/categories/${slug}/items`, actionHref, 'Edit');
   }
 
   static #renderInfo(item) {

--- a/frontend/assets/js/components/pages/helpers/PageActionsHelper.jsx
+++ b/frontend/assets/js/components/pages/helpers/PageActionsHelper.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+/**
+ * Builds common page action buttons.
+ */
+export default class PageActionsHelper {
+  /**
+   * Renders a default actions row with back and optional primary action.
+   *
+   * @param {string} backHref back destination
+   * @param {string|null} actionHref primary action destination
+   * @param {string|null} actionLabel primary action label
+   * @returns {JSX.Element} action buttons row
+   */
+  static render(backHref, actionHref, actionLabel) {
+    return (
+      <div className='mb-3'>
+        {this.#renderBackButton(backHref)}
+        {this.#renderPrimaryButton(actionHref, actionLabel)}
+      </div>
+    );
+  }
+
+  static #renderBackButton(backHref) {
+    return (
+      <a className='btn btn-outline-secondary me-2' href={backHref}>
+        Back
+      </a>
+    );
+  }
+
+  static #renderPrimaryButton(actionHref, actionLabel) {
+    if (!actionHref || !actionLabel) {
+      return null;
+    }
+
+    return (
+      <a className='btn btn-primary' href={actionHref}>
+        {actionLabel}
+      </a>
+    );
+  }
+}

--- a/frontend/assets/js/utils/HashRouteResolver.js
+++ b/frontend/assets/js/utils/HashRouteResolver.js
@@ -21,6 +21,7 @@ export default class HashRouteResolver {
     router.register('/categories/:slug/items/new', 'categoryItemNew');
     router.register('/categories/:slug/items/:id', 'categoryItem');
     router.register('/categories/:slug/items', 'categoryItems');
+    router.register('/categories/:slug', 'category');
     router.register('/categories', 'categories');
     router.register('/kinds', 'kinds');
     return router;

--- a/frontend/spec/components/helpers/AppHelper_spec.js
+++ b/frontend/spec/components/helpers/AppHelper_spec.js
@@ -35,6 +35,12 @@ describe('AppHelper', function() {
       expect(html).toContain('Loading categories...');
     });
 
+    it('renders the Category component for "category" page', function() {
+      const html = renderPage('category');
+
+      expect(html).toContain('Loading category...');
+    });
+
     it('does not render the home placeholder for "categories" page', function() {
       const html = renderPage('categories');
 

--- a/frontend/spec/components/pages/Category_spec.js
+++ b/frontend/spec/components/pages/Category_spec.js
@@ -1,0 +1,6 @@
+import Category from '../../../assets/js/components/pages/Category.jsx';
+import { itRendersPageLoadingState } from '../../support/shared_examples/pageExamples.js';
+
+describe('Category', function() {
+  itRendersPageLoadingState(Category, 'Loading category...');
+});

--- a/frontend/spec/components/pages/controllers/CategoryController_spec.js
+++ b/frontend/spec/components/pages/controllers/CategoryController_spec.js
@@ -1,0 +1,158 @@
+import CategoryController, { getCategorySlugFromHash } from '../../../../assets/js/components/pages/controllers/CategoryController.js';
+import GenericClient from '../../../../assets/js/client/GenericClient.js';
+import {
+  buildSpies,
+  flushPromises,
+} from '../../../support/factories.js';
+
+describe('CategoryController', function() {
+  let mockClient;
+
+  const buildMockClient = (overrides = {}) => ({
+    currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/project'),
+    fetch: jasmine.createSpy('fetch').and.returnValue(
+      Promise.resolve({ slug: 'project', name: 'Project', kinds: [] })
+    ),
+    ...overrides,
+  });
+
+  const buildSetters = () => buildSpies(
+    'setCategory',
+    'setLoading',
+    'setError'
+  );
+
+  beforeEach(function() {
+    mockClient = buildMockClient();
+  });
+
+  describe('getCategorySlugFromHash', function() {
+    it('extracts slug from hash route', function() {
+      const slug = getCategorySlugFromHash('#/categories/project?page=2');
+
+      expect(slug).toBe('project');
+    });
+
+    it('extracts slug from a route with trailing slash', function() {
+      const slug = getCategorySlugFromHash('#/categories/project/?page=2');
+
+      expect(slug).toBe('project');
+    });
+
+    it('returns empty slug when hash does not match category route', function() {
+      const slug = getCategorySlugFromHash('#/categories');
+
+      expect(slug).toBe('');
+    });
+  });
+
+  it('fetches category in buildEffect', async function() {
+    const { setCategory, setLoading, setError } = buildSetters();
+    const category = {
+      slug: 'project',
+      name: 'Project',
+      kinds: [{ slug: 'code', name: 'Code' }],
+    };
+
+    mockClient = buildMockClient({
+      currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/project?foo=bar'),
+      fetch: jasmine.createSpy('fetch').and.returnValue(Promise.resolve(category)),
+    });
+
+    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const cleanup = controller.buildEffect()();
+
+    await flushPromises();
+
+    expect(mockClient.fetch).toHaveBeenCalledWith('/categories/project.json');
+    expect(setCategory).toHaveBeenCalledWith(category);
+    expect(setLoading).toHaveBeenCalledWith(false);
+    expect(setError).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('normalizes missing kinds to an empty array', async function() {
+    const { setCategory, setLoading, setError } = buildSetters();
+
+    mockClient = buildMockClient({
+      fetch: jasmine.createSpy('fetch').and.returnValue(
+        Promise.resolve({ slug: 'project', name: 'Project' })
+      ),
+    });
+
+    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const cleanup = controller.buildEffect()();
+
+    await flushPromises();
+
+    expect(setCategory).toHaveBeenCalledWith({ slug: 'project', name: 'Project', kinds: [] });
+    expect(setError).not.toHaveBeenCalled();
+    expect(setLoading).toHaveBeenCalledWith(false);
+
+    cleanup();
+  });
+
+  it('calls setError when category fetch fails', async function() {
+    const { setCategory, setLoading, setError } = buildSetters();
+
+    mockClient = buildMockClient({
+      fetch: jasmine.createSpy('fetch').and.returnValue(
+        Promise.reject(new Error('Request failed for /categories/project.json'))
+      ),
+    });
+
+    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const cleanup = controller.buildEffect()();
+
+    await flushPromises();
+
+    expect(setCategory).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenCalledWith('Unable to load category.');
+    expect(setLoading).toHaveBeenCalledWith(false);
+
+    cleanup();
+  });
+
+  it('calls setError when params cannot be extracted from hash', async function() {
+    const { setCategory, setLoading, setError } = buildSetters();
+
+    mockClient = buildMockClient({
+      currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories'),
+    });
+
+    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const cleanup = controller.buildEffect()();
+
+    await flushPromises();
+
+    expect(mockClient.fetch).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenCalledWith('Unable to load category.');
+    expect(setLoading).toHaveBeenCalledWith(false);
+
+    cleanup();
+  });
+
+  it('does not call setters after unmount', async function() {
+    const { setCategory, setLoading, setError } = buildSetters();
+
+    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const cleanup = controller.buildEffect()();
+
+    cleanup();
+
+    await flushPromises();
+
+    expect(setCategory).not.toHaveBeenCalled();
+    expect(setLoading).not.toHaveBeenCalled();
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('defaults client to a new GenericClient when none is provided', function() {
+    const { setCategory, setLoading, setError } = buildSetters();
+
+    const controller = new CategoryController(setCategory, setLoading, setError);
+
+    expect(controller.client).toBeInstanceOf(GenericClient);
+  });
+});

--- a/frontend/spec/components/pages/helpers/CategoriesHelper_spec.js
+++ b/frontend/spec/components/pages/helpers/CategoriesHelper_spec.js
@@ -18,7 +18,7 @@ describe('CategoriesHelper', function() {
     const html = renderStatic(CategoriesHelper.render(categories, false, { page: 1, pages: 1, perPage: 10 }));
 
     expect(html).toContain('Project');
-    expect(html).toContain('/#/categories/project/items');
+    expect(html).toContain('/#/categories/project');
     expect(html).toContain('http://example.com/snap.png');
     expect(html).not.toContain('/#/categories/new');
   });
@@ -42,8 +42,8 @@ describe('CategoriesHelper', function() {
 
     expect(html).toContain('Project');
     expect(html).toContain('Miniatures');
-    expect(html).toContain('/#/categories/project/items');
-    expect(html).toContain('/#/categories/miniatures/items');
+    expect(html).toContain('/#/categories/project');
+    expect(html).toContain('/#/categories/miniatures');
     expect(html).toContain('http://example.com/mini.png');
   });
 });

--- a/frontend/spec/components/pages/helpers/CategoryHelper_spec.js
+++ b/frontend/spec/components/pages/helpers/CategoryHelper_spec.js
@@ -1,0 +1,43 @@
+import CategoryHelper from '../../../../assets/js/components/pages/helpers/CategoryHelper.jsx';
+import { renderStatic } from '../../../support/factories.js';
+import { itRendersLoadingAndErrorStates } from '../../../support/shared_examples/pageHelperExamples.js';
+
+describe('CategoryHelper', function() {
+  const category = {
+    slug: 'project',
+    name: 'Project',
+    snap_url: 'http://example.com/project.png',
+    kinds: [
+      { slug: 'code', name: 'Code' },
+      { slug: 'hardware', name: 'Hardware' },
+    ],
+  };
+
+  itRendersLoadingAndErrorStates(CategoryHelper, 'Loading category...');
+
+  it('renders actions and category data', function() {
+    const html = renderStatic(CategoryHelper.render(category));
+
+    expect(html).toContain('/#/categories');
+    expect(html).toContain('/#/categories/project/items');
+    expect(html).toContain('Back');
+    expect(html).toContain('Items');
+    expect(html).toContain('Project');
+    expect(html).toContain('http://example.com/project.png');
+  });
+
+  it('renders connected kinds as badges', function() {
+    const html = renderStatic(CategoryHelper.render(category));
+
+    expect(html).toContain('Kinds');
+    expect(html).toContain('Code');
+    expect(html).toContain('Hardware');
+    expect(html).toContain('badge');
+  });
+
+  it('renders empty kinds message when category has no kinds', function() {
+    const html = renderStatic(CategoryHelper.render({ ...category, kinds: [] }));
+
+    expect(html).toContain('No kinds connected.');
+  });
+});

--- a/frontend/spec/utils/HashRouteResolver_spec.js
+++ b/frontend/spec/utils/HashRouteResolver_spec.js
@@ -52,6 +52,12 @@ describe('HashRouteResolver', function() {
       expect(resolver.getPage()).toBe('categoryItems');
     });
 
+    it('returns "category" for category routes', function() {
+      const resolver = new HashRouteResolver(() => '#/categories/project?page=2&per_page=10');
+
+      expect(resolver.getPage()).toBe('category');
+    });
+
     it('returns "categories" for categories routes', function() {
       const resolver = new HashRouteResolver(() => '#/categories');
 


### PR DESCRIPTION
Implements the new frontend category show view at `/#/categories/:slug`, loading `/categories/:slug.json` and rendering category details plus connected kinds with UX aligned to existing category item pages.

- **Routing + page registration**
  - Added hash route resolution for `/#/categories/:slug` in `HashRouteResolver`.
  - Registered new `category` page in `AppHelper`.
  - Updated category catalog cards to navigate to category show route (`/#/categories/:slug`) instead of directly to items.

- **New category show page**
  - Added `Category.jsx` page component with standard loading/error/content flow.
  - Added `CategoryController` to:
    - parse slug from hash route
    - fetch `/categories/:slug.json`
    - normalize `kinds` to an array
    - handle invalid route/fetch failures with consistent error messaging
  - Added `CategoryHelper` to render:
    - category name (card header)
    - category `snap_url` image
    - connected kinds as badges
    - contextual actions (`Back` to categories, `Items` to category items)

- **Focused spec coverage**
  - Added specs for new page, controller, and helper.
  - Extended existing routing/app helper specs for the new `category` page resolution/rendering.
  - Updated categories helper specs to assert new category card destination route.

```js
// CategoryController fetch path
return this.client.fetch(`/categories/${slug}.json`)
  .then((category) => ({
    ...category,
    kinds: Array.isArray(category.kinds) ? category.kinds : [],
  }));
```

Fixes #96 
