### PR TITLE
Add category creation page to new frontend

### DIFF
--- a/frontend/assets/js/components/elements/CategoryKindBadge.jsx
+++ b/frontend/assets/js/components/elements/CategoryKindBadge.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * Renders a single kind badge, optionally with a remove button.
+ *
+ * When `onRemove` is provided the badge includes a Remove button (editor mode).
+ * Without it the badge is rendered read-only (display mode).
+ *
+ * @param {Object} props component props
+ * @param {Object} props.kind kind data with slug and name
+ * @param {Function} [props.onRemove] optional callback(slug) when Remove button is clicked
+ * @returns {JSX.Element} kind badge
+ */
+export default function CategoryKindBadge({ kind, onRemove }) {
+  if (onRemove) {
+    return (
+      <span className='badge bg-primary d-flex align-items-center gap-1'>
+        {kind.name}
+        <button
+          className='btn btn-sm btn-danger ms-1'
+          onClick={() => onRemove(kind.slug)}
+          type='button'
+        >
+          x
+        </button>
+      </span>
+    );
+  }
+
+  return (
+    <span className='badge text-bg-primary me-2 mb-2'>
+      {kind.name}
+    </span>
+  );
+}

--- a/frontend/assets/js/components/elements/CategoryKindSelectInput.jsx
+++ b/frontend/assets/js/components/elements/CategoryKindSelectInput.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import CollectionSelect from './CollectionSelect.jsx';
+
+/**
+ * Renders a kind select dropdown paired with an Add button.
+ *
+ * @param {Object} props component props
+ * @param {Array<Object>} props.kinds all available kind options
+ * @param {string} props.selectedSlug slug of the currently chosen kind
+ * @param {Function} props.onSelectChange callback(slug) when select value changes
+ * @param {Function} props.onAddKind callback() when Add button is clicked
+ * @returns {JSX.Element} select dropdown with add button
+ */
+export default function CategoryKindSelectInput({
+  kinds,
+  selectedSlug,
+  onSelectChange,
+  onAddKind,
+}) {
+  return (
+    <div className='d-flex align-items-center gap-2'>
+      <CollectionSelect
+        collection={kinds}
+        id='category-new-kind-select'
+        keyColumn='slug'
+        labelColumn='name'
+        onChange={onSelectChange}
+        placeholder='-- Select a kind --'
+        selectedValue={selectedSlug || ''}
+      />
+      <button className='btn btn-success' onClick={onAddKind} type='button'>
+        Add
+      </button>
+    </div>
+  );
+}

--- a/frontend/assets/js/components/elements/CategoryKinds.jsx
+++ b/frontend/assets/js/components/elements/CategoryKinds.jsx
@@ -17,7 +17,7 @@ export default function CategoryKinds({ kinds }) {
     <>
       <p className='mb-2'>Kinds</p>
       <div className='d-flex flex-wrap'>
-        {kinds.map((kind) => CategoryKindsHelper.renderKindBadge(kind))}
+        {CategoryKindsHelper.renderKindsBadges(kinds)}
       </div>
     </>
   );

--- a/frontend/assets/js/components/elements/CategoryKindsEditor.jsx
+++ b/frontend/assets/js/components/elements/CategoryKindsEditor.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import CategoryKindsEditorList from './CategoryKindsEditorList.jsx';
+import CategoryKindsEditorSelect from './CategoryKindsEditorSelect.jsx';
+
+/**
+ * Renders an editable kinds selector for category forms.
+ *
+ * Displays a select box with all available kinds plus an Add button, followed
+ * by the list of currently selected kinds each with a Remove button.
+ *
+ * @param {Object} props component props
+ * @param {Array<Object>} props.allKinds all available kind options
+ * @param {Array<Object>} props.selectedKinds currently selected kinds
+ * @param {string} props.selectedSlug slug of the currently chosen kind in the select
+ * @param {Function} props.onSelectChange callback(slug) when select value changes
+ * @param {Function} props.onAddKind callback() when Add button is clicked
+ * @param {Function} props.onRemoveKind callback(slug) when a kind Remove button is clicked
+ * @returns {JSX.Element} kinds editor section
+ */
+export default function CategoryKindsEditor({
+  allKinds,
+  selectedKinds,
+  selectedSlug,
+  onSelectChange,
+  onAddKind,
+  onRemoveKind,
+}) {
+  return (
+    <div className='border p-3 mb-3 bg-light rounded'>
+      <CategoryKindsEditorSelect
+        kinds={allKinds}
+        selectedSlug={selectedSlug}
+        onSelectChange={onSelectChange}
+        onAddKind={onAddKind}
+      />
+      <CategoryKindsEditorList
+        kinds={selectedKinds}
+        onRemoveKind={onRemoveKind}
+      />
+    </div>
+  );
+}

--- a/frontend/assets/js/components/elements/CategoryKindsEditorList.jsx
+++ b/frontend/assets/js/components/elements/CategoryKindsEditorList.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import CategoryKindsEditorListHelper from './helpers/CategoryKindsEditorListHelper.jsx';
+
+/**
+ * Renders the list of currently selected kinds with remove buttons, or an empty message.
+ *
+ * @param {Object} props component props
+ * @param {Array<Object>} props.kinds selected kinds
+ * @param {Function} props.onRemoveKind callback(slug) when a kind Remove button is clicked
+ * @returns {JSX.Element} selected kinds list
+ */
+export default function CategoryKindsEditorList({ kinds, onRemoveKind }) {
+  return (
+    <div>
+      <label className='form-label'>
+        Kinds
+      </label>
+      <div className='d-flex flex-wrap gap-2'>
+        {CategoryKindsEditorListHelper.renderKinds(kinds, onRemoveKind)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/assets/js/components/elements/CategoryKindsEditorSelect.jsx
+++ b/frontend/assets/js/components/elements/CategoryKindsEditorSelect.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import CategoryKindSelectInput from './CategoryKindSelectInput.jsx';
+
+/**
+ * Renders a labeled kind select box with an Add button for the kinds editor.
+ *
+ * @param {Object} props component props
+ * @param {Array<Object>} props.kinds all available kind options
+ * @param {string} props.selectedSlug slug of the currently chosen kind in the select
+ * @param {Function} props.onSelectChange callback(slug) when select value changes
+ * @param {Function} props.onAddKind callback() when Add button is clicked
+ * @returns {JSX.Element} labeled kind select with add button
+ */
+export default function CategoryKindsEditorSelect({
+  kinds,
+  selectedSlug,
+  onSelectChange,
+  onAddKind,
+}) {
+  return (
+    <div className='mb-3'>
+      <label className='form-label' htmlFor='category-new-kind-select'>
+        Add a Kind
+      </label>
+      <CategoryKindSelectInput
+        kinds={kinds}
+        onAddKind={onAddKind}
+        onSelectChange={onSelectChange}
+        selectedSlug={selectedSlug}
+      />
+    </div>
+  );
+}

--- a/frontend/assets/js/components/elements/CollectionSelect.jsx
+++ b/frontend/assets/js/components/elements/CollectionSelect.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import CollectionSelectHelper from './helpers/CollectionSelectHelper.jsx';
+
+/**
+ * Renders a generic select dropdown backed by a collection of objects.
+ *
+ * @param {Object} props component props
+ * @param {Array<Object>} props.collection items to render as options
+ * @param {string} props.keyColumn object property used as the option value and React key
+ * @param {string} props.labelColumn object property used as the option display text
+ * @param {string} props.selectedValue currently selected value
+ * @param {Function} props.onChange callback(value) when selection changes
+ * @param {string} [props.id] id attribute for the select element
+ * @param {string} [props.placeholder] text shown in the empty default option
+ * @param {string} [props.className] CSS class for the select element
+ * @returns {JSX.Element} select element
+ */
+export default function CollectionSelect({
+  collection,
+  keyColumn,
+  labelColumn,
+  selectedValue,
+  onChange,
+  id,
+  placeholder = '-- Select --',
+  className = 'form-select',
+}) {
+  return (
+    <select
+      className={className}
+      id={id}
+      onChange={(e) => onChange(e.target.value)}
+      value={selectedValue}
+    >
+      <option value=''>{placeholder}</option>
+      {CollectionSelectHelper.renderOptions(collection, keyColumn, labelColumn)}
+    </select>
+  );
+}

--- a/frontend/assets/js/components/elements/helpers/CategoryKindsEditorListHelper.jsx
+++ b/frontend/assets/js/components/elements/helpers/CategoryKindsEditorListHelper.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import CategoryKindBadge from '../CategoryKindBadge.jsx';
+
+/**
+ * Renders reusable pieces for the category kinds editor list.
+ */
+export default class CategoryKindsEditorListHelper {
+  /**
+   * Renders the list of selected kinds or an empty state message.
+   *
+   * @param {Array<Object>} kinds selected kinds
+   * @param {Function} onRemoveKind callback(slug) when a kind Remove button is clicked
+   * @returns {JSX.Element} kinds list or empty message
+   */
+  static renderKinds(kinds, onRemoveKind) {
+    if (kinds.length === 0) {
+      return <p className='mb-0'>No kinds selected.</p>;
+    }
+
+    return kinds.map((kind) => (
+      <CategoryKindBadge key={kind.slug} kind={kind} onRemove={onRemoveKind} />
+    ));
+  }
+}

--- a/frontend/assets/js/components/elements/helpers/CategoryKindsHelper.jsx
+++ b/frontend/assets/js/components/elements/helpers/CategoryKindsHelper.jsx
@@ -1,20 +1,19 @@
 import React from 'react';
+import CategoryKindBadge from '../CategoryKindBadge.jsx';
 
 /**
- * Builds category kinds UI fragments.
+ * Renders reusable pieces for the category kinds display.
  */
 export default class CategoryKindsHelper {
   /**
-   * Renders a category kind badge.
+   * Renders a list of kind badges for display (read-only).
    *
-   * @param {Object} kind category kind data
-   * @returns {JSX.Element} rendered badge
+   * @param {Array<Object>} kinds category kinds
+   * @returns {JSX.Element[]} array of kind badge elements
    */
-  static renderKindBadge(kind) {
-    return (
-      <span key={kind.slug} className='badge text-bg-primary me-2 mb-2'>
-        {kind.name}
-      </span>
-    );
+  static renderKindsBadges(kinds) {
+    return kinds.map((kind) => (
+      <CategoryKindBadge key={kind.slug} kind={kind} />
+    ));
   }
 }

--- a/frontend/assets/js/components/elements/helpers/CollectionSelectHelper.jsx
+++ b/frontend/assets/js/components/elements/helpers/CollectionSelectHelper.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+/**
+ * Renders reusable pieces for CollectionSelect.
+ */
+export default class CollectionSelectHelper {
+  /**
+   * Renders an array of option elements from a collection.
+   *
+   * @param {Array<Object>} collection items to render as options
+   * @param {string} keyColumn property used as the option value and React key
+   * @param {string} labelColumn property used as the option display text
+   * @returns {JSX.Element[]} array of option elements
+   */
+  static renderOptions(collection, keyColumn, labelColumn) {
+    return collection.map((item) => (
+      <option key={item[keyColumn]} value={item[keyColumn]}>
+        {item[labelColumn]}
+      </option>
+    ));
+  }
+}

--- a/frontend/assets/js/components/helpers/AppHelper.jsx
+++ b/frontend/assets/js/components/helpers/AppHelper.jsx
@@ -6,6 +6,7 @@ import CategoryItem from '../pages/CategoryItem.jsx';
 import CategoryItemEdit from '../pages/CategoryItemEdit.jsx';
 import CategoryItemNew from '../pages/CategoryItemNew.jsx';
 import CategoryItems from '../pages/CategoryItems.jsx';
+import CategoryNew from '../pages/CategoryNew.jsx';
 import Kinds from '../pages/Kinds.jsx';
 
 const PAGES = {
@@ -15,6 +16,7 @@ const PAGES = {
   categoryItemEdit: <CategoryItemEdit />,
   categoryItemNew: <CategoryItemNew />,
   categoryItems: <CategoryItems />,
+  categoryNew: <CategoryNew />,
   home: <Categories />,
   kinds: <Kinds />,
 };

--- a/frontend/assets/js/components/pages/CategoryNew.jsx
+++ b/frontend/assets/js/components/pages/CategoryNew.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useMemo, useState } from 'react';
+import CategoryNewController from './controllers/CategoryNewController.js';
+import CategoryNewHelper from './helpers/CategoryNewHelper.jsx';
+
+/**
+ * Page component that displays the category creation form.
+ *
+ * @returns {JSX.Element} new category page with loading, error, or form state
+ */
+export default function CategoryNew() {
+  const [category, setCategory] = useState(null);
+  const [kinds, setKinds] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const controller = useMemo(
+    () => new CategoryNewController(setCategory, setKinds, setLoading, setSaving, setError),
+    []
+  );
+
+  useEffect(() => {
+    const effect = controller.buildEffect();
+
+    return effect();
+  }, [controller]);
+
+  if (loading) {
+    return CategoryNewHelper.renderLoading();
+  }
+
+  if (error) {
+    return CategoryNewHelper.renderError(error);
+  }
+
+  if (!category) {
+    return CategoryNewHelper.renderError('Unable to load category new form.');
+  }
+
+  const selectedKind = kinds.find((k) => k.slug === category.kind_slug) || null;
+
+  return CategoryNewHelper.render(
+    category,
+    kinds,
+    saving,
+    (field, value) => controller.onFieldChange(field, value),
+    () => controller.onAddKind(selectedKind),
+    (slug) => controller.onRemoveKind(slug),
+    () => controller.save(category)
+  );
+}

--- a/frontend/assets/js/components/pages/controllers/CategoryNewController.js
+++ b/frontend/assets/js/components/pages/controllers/CategoryNewController.js
@@ -1,0 +1,185 @@
+import GenericClient from '../../../client/GenericClient.js';
+import BasePageController from './BasePageController.js';
+
+/**
+ * Manages category new page state and create flow.
+ */
+export default class CategoryNewController extends BasePageController {
+  /**
+   * Creates a new CategoryNewController instance.
+   *
+   * @param {Function} setCategory state setter for category data
+   * @param {Function} setKinds state setter for all available kinds
+   * @param {Function} setLoading state setter for loading status
+   * @param {Function} setSaving state setter for saving status
+   * @param {Function} setError state setter for error message
+   * @param {GenericClient|null} [client] optional client instance
+   * @param {Object|null} [locationTarget] optional location target used for redirects
+   */
+  constructor(setCategory, setKinds, setLoading, setSaving, setError, client = null, locationTarget = null) {
+    super();
+    this.setCategory = setCategory;
+    this.setKinds = setKinds;
+    this.setLoading = setLoading;
+    this.setSaving = setSaving;
+    this.setError = setError;
+    this.client = client ?? new GenericClient();
+    this.locationTarget = locationTarget ?? (typeof window === 'undefined' ? { hash: '' } : window.location);
+  }
+
+  /**
+   * Builds the React effect that loads new category form data and all kinds on mount.
+   *
+   * @returns {Function} effect function that starts loading and returns a cleanup function
+   */
+  buildEffect() {
+    return () => {
+      let mounted = true;
+      const safeSet = this.buildSafeSetter(() => mounted);
+
+      this.#loadData(safeSet);
+
+      return () => {
+        mounted = false;
+      };
+    };
+  }
+
+  /**
+   * Creates a new category and redirects to the category page on success.
+   *
+   * @param {Object} category category state to submit
+   * @returns {Promise<void>} save promise
+   */
+  save(category) {
+    if (!category) {
+      this.setError('Unable to save category.');
+      return Promise.reject(new Error('Unable to save category.'));
+    }
+
+    this.setSaving(true);
+    this.setError(null);
+
+    return this.client.post('/categories.json', this.#buildPayload(category))
+      .then((saved) => this.#onSaveSuccess(saved))
+      .catch(() => this.#onSaveError())
+      .finally(() => this.#finalizeSave());
+  }
+
+  /**
+   * Updates a single field on the current category state.
+   *
+   * @param {string} field field name to update
+   * @param {string} value new field value
+   */
+  onFieldChange(field, value) {
+    this.setCategory((current) => ({ ...current, [field]: value }));
+  }
+
+  /**
+   * Adds a kind to the category kinds list if not already present.
+   *
+   * @param {Object|null} kind kind object with slug and name to add
+   */
+  onAddKind(kind) {
+    if (!kind || !kind.slug) {
+      return;
+    }
+
+    this.setCategory((current) => {
+      const kinds = current.kinds || [];
+
+      if (kinds.some((k) => k.slug === kind.slug)) {
+        return current;
+      }
+
+      return { ...current, kinds: [...kinds, kind] };
+    });
+  }
+
+  /**
+   * Removes the kind with the given slug from the category kinds list.
+   *
+   * @param {string} slug slug of the kind to remove
+   */
+  onRemoveKind(slug) {
+    this.setCategory((current) => ({
+      ...current,
+      kinds: (current.kinds || []).filter((k) => k.slug !== slug),
+    }));
+  }
+
+  /**
+   * Returns the cancel/back href for the new category page.
+   *
+   * @returns {string} href pointing to the categories index
+   */
+  cancelHref() {
+    return '/#/categories';
+  }
+
+  #loadData(safeSet) {
+    Promise.all([
+      this.#fetchCategory(),
+      this.#fetchKinds(),
+    ])
+      .then(([category, kinds]) => this.#applyLoadedData(safeSet, category, kinds))
+      .catch((error) => this.#onLoadError(safeSet, error))
+      .finally(() => this.#finalizeLoad(safeSet));
+  }
+
+  #fetchCategory() {
+    return this.client.fetch('/categories/new.json')
+      .then(CategoryNewController.#normalizeCategory)
+      .catch(() => { throw new Error('Unable to load category new form.'); });
+  }
+
+  #fetchKinds() {
+    return this.client.fetch('/kinds.json')
+      .then((kinds) => (Array.isArray(kinds) ? kinds : []))
+      .catch(() => { throw new Error('Unable to load category new form.'); });
+  }
+
+  static #normalizeCategory(category) {
+    return {
+      ...category,
+      name: category.name || '',
+      kinds: Array.isArray(category.kinds) ? category.kinds : [],
+    };
+  }
+
+  #buildPayload(category) {
+    return {
+      category: {
+        name: category.name || '',
+        kinds: (category.kinds || []).map((k) => ({ slug: k.slug })),
+      },
+    };
+  }
+
+  #applyLoadedData(safeSet, category, kinds) {
+    safeSet(this.setCategory, category);
+    safeSet(this.setKinds, kinds);
+  }
+
+  #onSaveSuccess(saved) {
+    const slug = saved?.slug || '';
+    this.locationTarget.hash = `#/categories/${slug}`;
+  }
+
+  #onSaveError() {
+    this.setError('Unable to save category.');
+  }
+
+  #finalizeSave() {
+    this.setSaving(false);
+  }
+
+  #onLoadError(safeSet, error) {
+    safeSet(this.setError, error?.message || 'Unable to load category new form.');
+  }
+
+  #finalizeLoad(safeSet) {
+    safeSet(this.setLoading, false);
+  }
+}

--- a/frontend/assets/js/components/pages/helpers/CategoryNewHelper.jsx
+++ b/frontend/assets/js/components/pages/helpers/CategoryNewHelper.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import CategoryItemInfoCard from '../../elements/CategoryItemInfoCard.jsx';
+import CategoryKindsEditor from '../../elements/CategoryKindsEditor.jsx';
+import ErrorContainer from '../../elements/ErrorContainer.jsx';
+import LabeledInput from '../../elements/LabeledInput.jsx';
+import LoadingMessage from '../../elements/LoadingMessage.jsx';
+
+/**
+ * Renders the category new page HTML for different states.
+ */
+export default class CategoryNewHelper {
+  /**
+   * Renders the category new page in a loading state.
+   *
+   * @returns {JSX.Element} loading placeholder
+   */
+  static renderLoading() {
+    return <LoadingMessage message='Loading category new form...' />;
+  }
+
+  /**
+   * Renders the category new page in an error state.
+   *
+   * @param {string} error error message to display
+   * @returns {JSX.Element} error alert container
+   */
+  static renderError(error) {
+    return <ErrorContainer error={error} />;
+  }
+
+  /**
+   * Renders the fully populated category new form.
+   *
+   * @param {Object} category category data
+   * @param {Array<Object>} allKinds all available kinds for the select
+   * @param {boolean} saving whether save is currently in progress
+   * @param {Function} onFieldChange callback(field, value)
+   * @param {Function} onAddKind callback() when Add kind button is clicked
+   * @param {Function} onRemoveKind callback(slug) when a kind is removed
+   * @param {Function} onSave callback() when Save button is clicked
+   * @returns {JSX.Element} category new form content
+   */
+  static render(category, allKinds, saving, onFieldChange, onAddKind, onRemoveKind, onSave) {
+    return (
+      <div className='container mt-4'>
+        {this.#renderActions(saving, onSave)}
+        <CategoryItemInfoCard name={category.name || 'New Category'}>
+          <LabeledInput
+            id='category-new-name'
+            label='Name'
+            value={category.name || ''}
+            onChange={this.#buildFieldChangeHandler(onFieldChange, 'name')}
+          />
+          <CategoryKindsEditor
+            allKinds={allKinds}
+            selectedKinds={category.kinds || []}
+            selectedSlug={category.kind_slug || ''}
+            onSelectChange={(slug) => onFieldChange('kind_slug', slug)}
+            onAddKind={onAddKind}
+            onRemoveKind={onRemoveKind}
+          />
+        </CategoryItemInfoCard>
+      </div>
+    );
+  }
+
+  static #renderActions(saving, onSave) {
+    return (
+      <div className='mb-3'>
+        <a className='btn btn-outline-secondary me-2' href='/#/categories'>
+          Back
+        </a>
+        <button className='btn btn-success' disabled={saving} onClick={onSave} type='button'>
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    );
+  }
+
+  static #buildFieldChangeHandler(onFieldChange, field) {
+    return (event) => onFieldChange(field, event.target.value);
+  }
+}

--- a/frontend/assets/js/utils/HashRouteResolver.js
+++ b/frontend/assets/js/utils/HashRouteResolver.js
@@ -21,6 +21,7 @@ export default class HashRouteResolver {
     router.register('/categories/:slug/items/new', 'categoryItemNew');
     router.register('/categories/:slug/items/:id', 'categoryItem');
     router.register('/categories/:slug/items', 'categoryItems');
+    router.register('/categories/new', 'categoryNew');
     router.register('/categories/:slug', 'category');
     router.register('/categories', 'categories');
     router.register('/kinds', 'kinds');

--- a/frontend/spec/components/elements/CategoryKindBadge_spec.js
+++ b/frontend/spec/components/elements/CategoryKindBadge_spec.js
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import CategoryKindBadge from '../../../assets/js/components/elements/CategoryKindBadge.jsx';
+
+describe('CategoryKindBadge', function() {
+  const kind = { slug: 'code', name: 'Code' };
+
+  it('renders the kind name', function() {
+    const html = renderToStaticMarkup(CategoryKindBadge({ kind, onRemove: () => {} }));
+
+    expect(html).toContain('Code');
+    expect(html).toContain('badge');
+  });
+
+  it('renders a remove button when onRemove is provided', function() {
+    const html = renderToStaticMarkup(CategoryKindBadge({ kind, onRemove: () => {} }));
+
+    expect(html).toContain('x');
+    expect(html).toContain('btn-danger');
+  });
+
+  describe('without onRemove', function() {
+    it('renders the kind name as a read-only badge', function() {
+      const html = renderToStaticMarkup(CategoryKindBadge({ kind }));
+
+      expect(html).toContain('Code');
+      expect(html).toContain('badge');
+    });
+
+    it('does not render a remove button', function() {
+      const html = renderToStaticMarkup(CategoryKindBadge({ kind }));
+
+      expect(html).not.toContain('btn-danger');
+    });
+  });
+});

--- a/frontend/spec/components/elements/CategoryKindSelectInput_spec.js
+++ b/frontend/spec/components/elements/CategoryKindSelectInput_spec.js
@@ -1,0 +1,49 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import CategoryKindSelectInput from '../../../assets/js/components/elements/CategoryKindSelectInput.jsx';
+
+describe('CategoryKindSelectInput', function() {
+  const kinds = [{ slug: 'code', name: 'Code' }, { slug: 'hardware', name: 'Hardware' }];
+
+  it('renders a select with all available kinds', function() {
+    const html = renderToStaticMarkup(
+      CategoryKindSelectInput({
+        kinds,
+        selectedSlug: '',
+        onSelectChange: () => {},
+        onAddKind: () => {},
+      })
+    );
+
+    expect(html).toContain('Code');
+    expect(html).toContain('Hardware');
+    expect(html).toContain('Select a kind');
+    expect(html).toContain('form-select');
+  });
+
+  it('renders an Add button', function() {
+    const html = renderToStaticMarkup(
+      CategoryKindSelectInput({
+        kinds,
+        selectedSlug: '',
+        onSelectChange: () => {},
+        onAddKind: () => {},
+      })
+    );
+
+    expect(html).toContain('Add');
+    expect(html).toContain('btn-success');
+  });
+
+  it('marks the selected option', function() {
+    const html = renderToStaticMarkup(
+      CategoryKindSelectInput({
+        kinds,
+        selectedSlug: 'code',
+        onSelectChange: () => {},
+        onAddKind: () => {},
+      })
+    );
+
+    expect(html).toContain('value="code"');
+  });
+});

--- a/frontend/spec/components/elements/CategoryKindsEditorList_spec.js
+++ b/frontend/spec/components/elements/CategoryKindsEditorList_spec.js
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import CategoryKindsEditorList from '../../../assets/js/components/elements/CategoryKindsEditorList.jsx';
+
+describe('CategoryKindsEditorList', function() {
+  it('renders selected kinds as removable badges', function() {
+    const html = renderToStaticMarkup(
+      CategoryKindsEditorList({
+        kinds: [{ slug: 'code', name: 'Code' }, { slug: 'hardware', name: 'Hardware' }],
+        onRemoveKind: () => {},
+      })
+    );
+
+    expect(html).toContain('Kinds');
+    expect(html).toContain('Code');
+    expect(html).toContain('Hardware');
+    expect(html).toContain('badge');
+  });
+
+  it('renders empty message when no kinds are selected', function() {
+    const html = renderToStaticMarkup(
+      CategoryKindsEditorList({ kinds: [], onRemoveKind: () => {} })
+    );
+
+    expect(html).toContain('No kinds selected.');
+    expect(html).not.toContain('badge');
+  });
+});

--- a/frontend/spec/components/elements/CategoryKindsEditorSelect_spec.js
+++ b/frontend/spec/components/elements/CategoryKindsEditorSelect_spec.js
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import CategoryKindsEditorSelect from '../../../assets/js/components/elements/CategoryKindsEditorSelect.jsx';
+
+describe('CategoryKindsEditorSelect', function() {
+  const kinds = [{ slug: 'code', name: 'Code' }, { slug: 'hardware', name: 'Hardware' }];
+
+  it('renders a select with all available kinds', function() {
+    const html = renderToStaticMarkup(
+      CategoryKindsEditorSelect({
+        kinds,
+        selectedSlug: '',
+        onSelectChange: () => {},
+        onAddKind: () => {},
+      })
+    );
+
+    expect(html).toContain('Add a Kind');
+    expect(html).toContain('Code');
+    expect(html).toContain('Hardware');
+    expect(html).toContain('Select a kind');
+  });
+
+  it('renders an Add button', function() {
+    const html = renderToStaticMarkup(
+      CategoryKindsEditorSelect({
+        kinds,
+        selectedSlug: '',
+        onSelectChange: () => {},
+        onAddKind: () => {},
+      })
+    );
+
+    expect(html).toContain('Add');
+    expect(html).toContain('btn-success');
+  });
+});

--- a/frontend/spec/components/elements/CollectionSelect_spec.js
+++ b/frontend/spec/components/elements/CollectionSelect_spec.js
@@ -1,0 +1,88 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import CollectionSelect from '../../../assets/js/components/elements/CollectionSelect.jsx';
+
+describe('CollectionSelect', function() {
+  const collection = [
+    { slug: 'code', name: 'Code' },
+    { slug: 'hardware', name: 'Hardware' },
+  ];
+
+  it('renders options from the collection using keyColumn and labelColumn', function() {
+    const html = renderToStaticMarkup(
+      CollectionSelect({
+        collection,
+        keyColumn: 'slug',
+        labelColumn: 'name',
+        selectedValue: '',
+        onChange: () => {},
+      })
+    );
+
+    expect(html).toContain('value="code"');
+    expect(html).toContain('Code');
+    expect(html).toContain('value="hardware"');
+    expect(html).toContain('Hardware');
+    expect(html).toContain('form-select');
+  });
+
+  it('renders the placeholder as the default empty option', function() {
+    const html = renderToStaticMarkup(
+      CollectionSelect({
+        collection,
+        keyColumn: 'slug',
+        labelColumn: 'name',
+        selectedValue: '',
+        onChange: () => {},
+        placeholder: '-- Pick one --',
+      })
+    );
+
+    expect(html).toContain('-- Pick one --');
+    expect(html).toContain('value=""');
+  });
+
+  it('applies the default placeholder when none is provided', function() {
+    const html = renderToStaticMarkup(
+      CollectionSelect({
+        collection,
+        keyColumn: 'slug',
+        labelColumn: 'name',
+        selectedValue: '',
+        onChange: () => {},
+      })
+    );
+
+    expect(html).toContain('-- Select --');
+  });
+
+  it('marks the selected option', function() {
+    const html = renderToStaticMarkup(
+      CollectionSelect({
+        collection,
+        keyColumn: 'slug',
+        labelColumn: 'name',
+        selectedValue: 'hardware',
+        onChange: () => {},
+      })
+    );
+
+    expect(html).toContain('value="hardware"');
+  });
+
+  it('uses the provided id and className', function() {
+    const html = renderToStaticMarkup(
+      CollectionSelect({
+        collection,
+        keyColumn: 'slug',
+        labelColumn: 'name',
+        selectedValue: '',
+        onChange: () => {},
+        id: 'my-select',
+        className: 'custom-class',
+      })
+    );
+
+    expect(html).toContain('id="my-select"');
+    expect(html).toContain('custom-class');
+  });
+});

--- a/frontend/spec/components/elements/helpers/CategoryKindsEditorListHelper_spec.js
+++ b/frontend/spec/components/elements/helpers/CategoryKindsEditorListHelper_spec.js
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import CategoryKindsEditorListHelper from '../../../../assets/js/components/elements/helpers/CategoryKindsEditorListHelper.jsx';
+
+describe('CategoryKindsEditorListHelper', function() {
+  describe('.renderKinds', function() {
+    it('renders kind badges when kinds are present', function() {
+      const html = renderToStaticMarkup(
+        CategoryKindsEditorListHelper.renderKinds(
+          [{ slug: 'code', name: 'Code' }, { slug: 'hardware', name: 'Hardware' }],
+          () => {}
+        )
+      );
+
+      expect(html).toContain('Code');
+      expect(html).toContain('Hardware');
+      expect(html).toContain('badge');
+    });
+
+    it('renders empty message when no kinds are selected', function() {
+      const html = renderToStaticMarkup(
+        CategoryKindsEditorListHelper.renderKinds([], () => {})
+      );
+
+      expect(html).toContain('No kinds selected.');
+      expect(html).not.toContain('badge');
+    });
+  });
+});

--- a/frontend/spec/components/elements/helpers/CategoryKindsHelper_spec.js
+++ b/frontend/spec/components/elements/helpers/CategoryKindsHelper_spec.js
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+import CategoryKindsHelper from '../../../../assets/js/components/elements/helpers/CategoryKindsHelper.jsx';
+
+describe('CategoryKindsHelper', function() {
+  describe('.renderKindsBadges', function() {
+    const kinds = [{ slug: 'code', name: 'Code' }, { slug: 'hardware', name: 'Hardware' }];
+
+    it('renders a badge for each kind', function() {
+      const html = renderToStaticMarkup(
+        React.createElement(React.Fragment, null, ...CategoryKindsHelper.renderKindsBadges(kinds))
+      );
+
+      expect(html).toContain('Code');
+      expect(html).toContain('Hardware');
+      expect(html).toContain('badge');
+    });
+
+    it('renders no remove button in display mode', function() {
+      const html = renderToStaticMarkup(
+        React.createElement(React.Fragment, null, ...CategoryKindsHelper.renderKindsBadges(kinds))
+      );
+
+      expect(html).not.toContain('btn-danger');
+    });
+  });
+});

--- a/frontend/spec/components/elements/helpers/CollectionSelectHelper_spec.js
+++ b/frontend/spec/components/elements/helpers/CollectionSelectHelper_spec.js
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+import CollectionSelectHelper from '../../../../assets/js/components/elements/helpers/CollectionSelectHelper.jsx';
+
+describe('CollectionSelectHelper', function() {
+  const collection = [
+    { slug: 'code', name: 'Code' },
+    { slug: 'hardware', name: 'Hardware' },
+  ];
+
+  describe('.renderOptions', function() {
+    it('renders an option for each item using keyColumn and labelColumn', function() {
+      const html = renderToStaticMarkup(
+        React.createElement('select', null, ...CollectionSelectHelper.renderOptions(collection, 'slug', 'name'))
+      );
+
+      expect(html).toContain('value="code"');
+      expect(html).toContain('Code');
+      expect(html).toContain('value="hardware"');
+      expect(html).toContain('Hardware');
+    });
+
+    it('uses keyColumn as the option value', function() {
+      const items = [{ id: 1, label: 'One' }, { id: 2, label: 'Two' }];
+      const html = renderToStaticMarkup(
+        React.createElement('select', null, ...CollectionSelectHelper.renderOptions(items, 'id', 'label'))
+      );
+
+      expect(html).toContain('value="1"');
+      expect(html).toContain('One');
+      expect(html).toContain('value="2"');
+      expect(html).toContain('Two');
+    });
+  });
+});

--- a/frontend/spec/components/pages/CategoryNew_spec.js
+++ b/frontend/spec/components/pages/CategoryNew_spec.js
@@ -1,0 +1,6 @@
+import CategoryNew from '../../../assets/js/components/pages/CategoryNew.jsx';
+import { itRendersPageLoadingState } from '../../support/shared_examples/pageExamples.js';
+
+describe('CategoryNew', function() {
+  itRendersPageLoadingState(CategoryNew, 'Loading category new form...');
+});

--- a/frontend/spec/components/pages/controllers/CategoryNewController_spec.js
+++ b/frontend/spec/components/pages/controllers/CategoryNewController_spec.js
@@ -1,0 +1,253 @@
+import CategoryNewController from '../../../../assets/js/components/pages/controllers/CategoryNewController.js';
+import GenericClient from '../../../../assets/js/client/GenericClient.js';
+import {
+  buildSpies,
+  flushPromises,
+} from '../../../support/factories.js';
+
+describe('CategoryNewController', function() {
+  let mockClient;
+  let mockLocation;
+
+  const buildMockClient = (overrides = {}) => ({
+    currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/new'),
+    fetch: jasmine.createSpy('fetch').and.callFake((path) => {
+      if (path === '/categories/new.json') {
+        return Promise.resolve({ name: '', slug: '', kinds: [] });
+      }
+
+      if (path === '/kinds.json') {
+        return Promise.resolve([
+          { slug: 'code', name: 'Code' },
+          { slug: 'hardware', name: 'Hardware' },
+        ]);
+      }
+
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    }),
+    post: jasmine.createSpy('post').and.returnValue(Promise.resolve({ slug: 'my-category' })),
+    ...overrides,
+  });
+
+  const buildSetters = () => buildSpies(
+    'setCategory',
+    'setKinds',
+    'setLoading',
+    'setSaving',
+    'setError'
+  );
+
+  const buildController = (setters, client = null, location = null) => {
+    const { setCategory, setKinds, setLoading, setSaving, setError } = setters;
+
+    return new CategoryNewController(
+      setCategory,
+      setKinds,
+      setLoading,
+      setSaving,
+      setError,
+      client ?? mockClient,
+      location ?? mockLocation
+    );
+  };
+
+  beforeEach(function() {
+    mockClient = buildMockClient();
+    mockLocation = { hash: '#/categories/new' };
+  });
+
+  it('loads new category form and all kinds in buildEffect', async function() {
+    const setters = buildSetters();
+    const { setCategory, setKinds, setLoading, setError } = setters;
+    const cleanup = buildController(setters).buildEffect()();
+
+    await flushPromises();
+
+    expect(mockClient.fetch).toHaveBeenCalledWith('/categories/new.json');
+    expect(mockClient.fetch).toHaveBeenCalledWith('/kinds.json');
+    expect(setCategory).toHaveBeenCalledWith(jasmine.objectContaining({ name: '', kinds: [] }));
+    expect(setKinds).toHaveBeenCalledWith([
+      { slug: 'code', name: 'Code' },
+      { slug: 'hardware', name: 'Hardware' },
+    ]);
+    expect(setLoading).toHaveBeenCalledWith(false);
+    expect(setError).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('normalizes missing kinds to an empty array', async function() {
+    mockClient = buildMockClient({
+      fetch: jasmine.createSpy('fetch').and.callFake((path) => {
+        if (path === '/categories/new.json') {
+          return Promise.resolve({ name: '', slug: '' });
+        }
+
+        return Promise.resolve([]);
+      }),
+    });
+    const setters = buildSetters();
+    const cleanup = buildController(setters).buildEffect()();
+
+    await flushPromises();
+
+    expect(setters.setCategory).toHaveBeenCalledWith(
+      jasmine.objectContaining({ name: '', kinds: [] })
+    );
+    expect(setters.setError).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('sets error when loading fails', async function() {
+    mockClient = buildMockClient({
+      fetch: jasmine.createSpy('fetch').and.returnValue(Promise.reject(new Error('boom'))),
+    });
+    const setters = buildSetters();
+    const cleanup = buildController(setters).buildEffect()();
+
+    await flushPromises();
+
+    expect(setters.setError).toHaveBeenCalledWith('Unable to load category new form.');
+    expect(setters.setLoading).toHaveBeenCalledWith(false);
+
+    cleanup();
+  });
+
+  it('does not call setters after unmount', async function() {
+    const setters = buildSetters();
+    const cleanup = buildController(setters).buildEffect()();
+
+    cleanup();
+
+    await flushPromises();
+
+    expect(setters.setCategory).not.toHaveBeenCalled();
+    expect(setters.setLoading).not.toHaveBeenCalled();
+    expect(setters.setError).not.toHaveBeenCalled();
+  });
+
+  it('posts payload and redirects to category page on save', async function() {
+    const setters = buildSetters();
+
+    await buildController(setters).save({
+      name: 'My Category',
+      kinds: [{ slug: 'code', name: 'Code' }],
+    });
+
+    expect(mockClient.post).toHaveBeenCalledWith('/categories.json', {
+      category: {
+        name: 'My Category',
+        kinds: [{ slug: 'code' }],
+      },
+    });
+    expect(mockLocation.hash).toBe('#/categories/my-category');
+    expect(setters.setSaving).toHaveBeenCalledWith(true);
+    expect(setters.setSaving).toHaveBeenCalledWith(false);
+    expect(setters.setError).toHaveBeenCalledWith(null);
+  });
+
+  it('sets error when save fails', async function() {
+    mockClient = buildMockClient({
+      post: jasmine.createSpy('post').and.returnValue(Promise.reject(new Error('boom'))),
+    });
+    const setters = buildSetters();
+
+    await buildController(setters).save({ name: 'My Category', kinds: [] });
+
+    expect(setters.setError).toHaveBeenCalledWith('Unable to save category.');
+    expect(setters.setSaving).toHaveBeenCalledWith(false);
+  });
+
+  it('rejects and sets error when category is null on save', async function() {
+    const setters = buildSetters();
+    let caught = false;
+
+    await buildController(setters).save(null).catch(() => { caught = true; });
+
+    expect(caught).toBe(true);
+    expect(setters.setError).toHaveBeenCalledWith('Unable to save category.');
+    expect(mockClient.post).not.toHaveBeenCalled();
+  });
+
+  describe('#onFieldChange', function() {
+    it('updates the specified field on the category', function() {
+      const setters = buildSetters();
+      const controller = buildController(setters);
+
+      controller.onFieldChange('name', 'Updated Name');
+
+      const updater = setters.setCategory.calls.mostRecent().args[0];
+
+      expect(updater({ name: 'Old', kinds: [] })).toEqual({ name: 'Updated Name', kinds: [] });
+    });
+  });
+
+  describe('#onAddKind', function() {
+    it('adds a kind to the category kinds list', function() {
+      const setters = buildSetters();
+      const controller = buildController(setters);
+
+      controller.onAddKind({ slug: 'code', name: 'Code' });
+
+      const updater = setters.setCategory.calls.mostRecent().args[0];
+
+      expect(updater({ name: 'Cat', kinds: [] })).toEqual({
+        name: 'Cat',
+        kinds: [{ slug: 'code', name: 'Code' }],
+      });
+    });
+
+    it('does not add a duplicate kind', function() {
+      const setters = buildSetters();
+      const controller = buildController(setters);
+      const state = { name: 'Cat', kinds: [{ slug: 'code', name: 'Code' }] };
+
+      controller.onAddKind({ slug: 'code', name: 'Code' });
+
+      expect(setters.setCategory.calls.mostRecent().args[0](state)).toEqual(state);
+    });
+
+    it('does nothing when kind is null', function() {
+      const setters = buildSetters();
+
+      buildController(setters).onAddKind(null);
+
+      expect(setters.setCategory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#onRemoveKind', function() {
+    it('removes the kind with the given slug', function() {
+      const setters = buildSetters();
+      const controller = buildController(setters);
+
+      controller.onRemoveKind('code');
+
+      const updater = setters.setCategory.calls.mostRecent().args[0];
+
+      expect(updater({
+        name: 'Cat',
+        kinds: [{ slug: 'code', name: 'Code' }, { slug: 'hardware', name: 'Hardware' }],
+      })).toEqual({
+        name: 'Cat',
+        kinds: [{ slug: 'hardware', name: 'Hardware' }],
+      });
+    });
+  });
+
+  describe('#cancelHref', function() {
+    it('returns the categories index href', function() {
+      expect(buildController(buildSetters()).cancelHref()).toBe('/#/categories');
+    });
+  });
+
+  it('defaults client to a new GenericClient when none is provided', function() {
+    const { setCategory, setKinds, setLoading, setSaving, setError } = buildSetters();
+    const controller = new CategoryNewController(
+      setCategory, setKinds, setLoading, setSaving, setError
+    );
+
+    expect(controller.client).toBeInstanceOf(GenericClient);
+  });
+});

--- a/frontend/spec/components/pages/helpers/CategoryNewHelper_spec.js
+++ b/frontend/spec/components/pages/helpers/CategoryNewHelper_spec.js
@@ -1,0 +1,90 @@
+import CategoryNewHelper from '../../../../assets/js/components/pages/helpers/CategoryNewHelper.jsx';
+import { renderStatic } from '../../../support/factories.js';
+import { itRendersLoadingAndErrorStates } from '../../../support/shared_examples/pageHelperExamples.js';
+
+describe('CategoryNewHelper', function() {
+  const category = {
+    name: 'My Category',
+    kinds: [{ slug: 'code', name: 'Code' }],
+    kind_slug: '',
+  };
+  const allKinds = [
+    { slug: 'code', name: 'Code' },
+    { slug: 'hardware', name: 'Hardware' },
+  ];
+
+  itRendersLoadingAndErrorStates(CategoryNewHelper, 'Loading category new form...');
+
+  it('renders form fields and actions', function() {
+    const html = renderStatic(
+      CategoryNewHelper.render(
+        category,
+        allKinds,
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {}
+      )
+    );
+
+    expect(html).toContain('/#/categories');
+    expect(html).toContain('Back');
+    expect(html).toContain('Save');
+    expect(html).toContain('Name');
+    expect(html).toContain('My Category');
+    expect(html).toContain('Add a Kind');
+    expect(html).toContain('Code');
+    expect(html).toContain('Hardware');
+  });
+
+  it('renders selected kinds with remove buttons', function() {
+    const html = renderStatic(
+      CategoryNewHelper.render(
+        category,
+        allKinds,
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {}
+      )
+    );
+
+    expect(html).toContain('Code');
+    expect(html).toContain('badge');
+  });
+
+  it('renders empty kinds message when no kinds are selected', function() {
+    const html = renderStatic(
+      CategoryNewHelper.render(
+        { ...category, kinds: [] },
+        allKinds,
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {}
+      )
+    );
+
+    expect(html).toContain('No kinds selected.');
+  });
+
+  it('shows Saving... and disables button when saving', function() {
+    const html = renderStatic(
+      CategoryNewHelper.render(
+        category,
+        allKinds,
+        true,
+        () => {},
+        () => {},
+        () => {},
+        () => {}
+      )
+    );
+
+    expect(html).toContain('Saving...');
+    expect(html).toContain('disabled');
+  });
+});

--- a/frontend/spec/utils/HashRouteResolver_spec.js
+++ b/frontend/spec/utils/HashRouteResolver_spec.js
@@ -52,6 +52,12 @@ describe('HashRouteResolver', function() {
       expect(resolver.getPage()).toBe('categoryItems');
     });
 
+    it('returns "categoryNew" for category new routes', function() {
+      const resolver = new HashRouteResolver(() => '#/categories/new');
+
+      expect(resolver.getPage()).toBe('categoryNew');
+    });
+
     it('returns "category" for category routes', function() {
       const resolver = new HashRouteResolver(() => '#/categories/project?page=2&per_page=10');
 


### PR DESCRIPTION
Implements `/#/categories/new` in the new React frontend, mirroring the pattern used by `/#/categories/:slug/items/new` for item creation.

## Routing

Added `/categories/new` to `HashRouteResolver` **before** `/categories/:slug` to prevent route conflicts. Wired `categoryNew` into `AppHelper`'s PAGES map.

## New components

- **`CategoryNewController`** — loads `/categories/new.json` + `/kinds.json` in parallel; POSTs to `/categories.json` on save; redirects to `/#/categories/:slug` on success. Handles `onAddKind(kind)` / `onRemoveKind(slug)` for the multi-kind list.
- **`CategoryKindsEditor`** — reusable element orchestrating focused sub-components: `CategoryKindsEditorSelect` (labeled wrapper), `CategoryKindSelectInput` (select + Add button), `CategoryKindsEditorList` (removable-badge list of selected kinds), and `CategoryKindBadge` (single kind badge); analogous to `CategoryItemLinksEditor`.
- **`CategoryKindBadge`** — single kind badge, rendered read-only (display mode) when no `onRemove` prop is provided, or with a Remove button (editor mode) when `onRemove` is provided. Used by both `CategoryKindsEditorList` (editor) and `CategoryKinds` (show category page).
- **`CollectionSelect`** — generic select element that accepts a `collection`, a `keyColumn` (used as the option `value` and React `key`), and a `labelColumn` (option display text). Reusable for any object array. Delegates option rendering to `CollectionSelectHelper.renderOptions`.
- **`CategoryKindSelectInput`** — kind select + Add button; delegates to `CollectionSelect` with `keyColumn='slug'` and `labelColumn='name'`.
- **`CategoryKindsEditorListHelper`** — helper encapsulating the empty-state / badge-list rendering logic for `CategoryKindsEditorList`.
- **`CategoryKindsHelper`** — helper providing `renderKindsBadges(kinds)` for rendering read-only kind badges; used by `CategoryKinds`.
- **`CollectionSelectHelper`** — helper providing `renderOptions(collection, keyColumn, labelColumn)` for rendering `<option>` elements; used by `CollectionSelect`.
- **`CategoryNewHelper`** — renders loading / error / form states using `LabeledInput` + `CategoryKindsEditor` + action buttons.
- **`CategoryNew`** — page component wiring state, controller, and helper. The component resolves the selected kind object before delegating to the controller:

```jsx
const selectedKind = kinds.find((k) => k.slug === category.kind_slug) || null;

return CategoryNewHelper.render(
  category, kinds, saving,
  (field, value) => controller.onFieldChange(field, value),
  () => controller.onAddKind(selectedKind),
  (slug) => controller.onRemoveKind(slug),
  () => controller.save(category)
);
```

## Refactored components

- **`CategoryKinds`** (show category page) — updated to use `CategoryKindBadge` via `CategoryKindsHelper.renderKindsBadges`, replacing the now-removed inline mapping and the earlier `CategoryKindsHelper` class.

Fixes #182 