### PR TITLE
Add category edit route/page in new frontend with logged-only show action

### DIFF
--- a/frontend/assets/js/components/helpers/AppHelper.jsx
+++ b/frontend/assets/js/components/helpers/AppHelper.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Header from '../elements/Header.jsx';
 import Category from '../pages/Category.jsx';
+import CategoryEdit from '../pages/CategoryEdit.jsx';
 import Categories from '../pages/Categories.jsx';
 import CategoryItem from '../pages/CategoryItem.jsx';
 import CategoryItemEdit from '../pages/CategoryItemEdit.jsx';
@@ -11,6 +12,7 @@ import Kinds from '../pages/Kinds.jsx';
 
 const PAGES = {
   category: <Category />,
+  categoryEdit: <CategoryEdit />,
   categories: <Categories />,
   categoryItem: <CategoryItem />,
   categoryItemEdit: <CategoryItemEdit />,

--- a/frontend/assets/js/components/pages/Category.jsx
+++ b/frontend/assets/js/components/pages/Category.jsx
@@ -9,11 +9,12 @@ import CategoryHelper from './helpers/CategoryHelper.jsx';
  */
 export default function Category() {
   const [category, setCategory] = useState(null);
+  const [logged, setLogged] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   const controller = useMemo(
-    () => new CategoryController(setCategory, setLoading, setError),
+    () => new CategoryController(setCategory, setLogged, setLoading, setError),
     []
   );
 
@@ -31,5 +32,5 @@ export default function Category() {
     return CategoryHelper.renderError(error);
   }
 
-  return CategoryHelper.render(category);
+  return CategoryHelper.render(category, logged);
 }

--- a/frontend/assets/js/components/pages/CategoryEdit.jsx
+++ b/frontend/assets/js/components/pages/CategoryEdit.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useMemo, useState } from 'react';
+import CategoryEditController from './controllers/CategoryEditController.js';
+import CategoryNewHelper from './helpers/CategoryNewHelper.jsx';
+
+/**
+ * Page component that displays the category edit form.
+ *
+ * @returns {JSX.Element} edit category page with loading, error, or form state
+ */
+export default function CategoryEdit() {
+  const [category, setCategory] = useState(null);
+  const [kinds, setKinds] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const controller = useMemo(
+    () => new CategoryEditController(setCategory, setKinds, setLoading, setSaving, setError),
+    []
+  );
+
+  useEffect(() => {
+    const effect = controller.buildEffect();
+
+    return effect();
+  }, [controller]);
+
+  if (loading) {
+    return CategoryNewHelper.renderLoading();
+  }
+
+  if (error) {
+    return CategoryNewHelper.renderError(error);
+  }
+
+  if (!category) {
+    return CategoryNewHelper.renderError('Unable to load category edit form.');
+  }
+
+  const selectedKind = kinds.find((k) => k.slug === category.kind_slug) || null;
+
+  return CategoryNewHelper.render(
+    category,
+    kinds,
+    saving,
+    (field, value) => controller.onFieldChange(field, value),
+    () => controller.onAddKind(selectedKind),
+    (slug) => controller.onRemoveKind(slug),
+    () => controller.save(category)
+  );
+}

--- a/frontend/assets/js/components/pages/controllers/CategoryController.js
+++ b/frontend/assets/js/components/pages/controllers/CategoryController.js
@@ -20,13 +20,15 @@ export default class CategoryController extends BasePageController {
    * Creates a new CategoryController instance.
    *
    * @param {Function} setCategory state setter for category data
+   * @param {Function} setLogged state setter for login status
    * @param {Function} setLoading state setter for loading status
    * @param {Function} setError state setter for error message
    * @param {GenericClient|null} [client] optional client instance
    */
-  constructor(setCategory, setLoading, setError, client = null) {
+  constructor(setCategory, setLogged, setLoading, setError, client = null) {
     super();
     this.setCategory = setCategory;
+    this.setLogged = setLogged;
     this.setLoading = setLoading;
     this.setError = setError;
     this.client = client ?? new GenericClient();
@@ -52,14 +54,22 @@ export default class CategoryController extends BasePageController {
   }
 
   #loadData(safeSet, slug) {
-    this.#fetchCategory(slug)
+    this.#fetchCategoryAndLogin(slug)
       .then(this.#setCategoryState.bind(this, safeSet))
       .catch(this.#setErrorState.bind(this, safeSet))
       .finally(this.#setLoadingState.bind(this, safeSet));
   }
 
-  #setCategoryState(safeSet, category) {
+  #fetchCategoryAndLogin(slug) {
+    return Promise.all([
+      this.#fetchCategory(slug),
+      this.checkLogin(),
+    ]);
+  }
+
+  #setCategoryState(safeSet, [category, logged]) {
     safeSet(this.setCategory, category);
+    safeSet(this.setLogged, logged);
   }
 
   #setErrorState(safeSet, error) {

--- a/frontend/assets/js/components/pages/controllers/CategoryEditController.js
+++ b/frontend/assets/js/components/pages/controllers/CategoryEditController.js
@@ -1,0 +1,93 @@
+import CategoryFormController from './CategoryFormController.js';
+import Router from '../../../utils/Router.js';
+
+/**
+ * Extracts category slug from a category edit hash route.
+ *
+ * @param {string} [hash=''] current location hash
+ * @returns {string} category slug or an empty string when it cannot be resolved
+ */
+export function getCategoryEditSlugFromHash(hash = '') {
+  return Router.extractParams('/categories/:slug/edit', hash).slug || '';
+}
+
+/**
+ * Manages category edit page state and update flow.
+ */
+export default class CategoryEditController extends CategoryFormController {
+
+  /**
+   * Builds the React effect that loads category edit form data and all kinds on mount.
+   *
+   * @returns {Function} effect function that starts loading and returns a cleanup function
+   */
+  buildEffect() {
+    return () => {
+      let mounted = true;
+      const safeSet = this.buildSafeSetter(() => mounted);
+      const slug = getCategoryEditSlugFromHash(this.client.currentHash());
+
+      this.#loadData(safeSet, slug);
+
+      return () => {
+        mounted = false;
+      };
+    };
+  }
+
+  /**
+   * Updates a category and redirects to the category page on success.
+   *
+   * @param {Object} category category state to submit
+   * @returns {Promise<void>} save promise
+   */
+  save(category) {
+    const slug = getCategoryEditSlugFromHash(this.client.currentHash());
+
+    if (!slug || !category) {
+      this.setError('Unable to save category.');
+      return Promise.reject(new Error('Unable to save category.'));
+    }
+
+    this.setSaving(true);
+    this.setError(null);
+
+    return this.client.patch(`/categories/${slug}`, this.buildPayload(category))
+      .then((saved) => this.#onSaveSuccess(saved, slug))
+      .catch(() => this.onSaveError())
+      .finally(() => this.finalizeSave());
+  }
+
+  #loadData(safeSet, slug) {
+    Promise.all([
+      this.#fetchCategory(slug),
+      this.#fetchKinds(),
+    ])
+      .then(([category, kinds]) => this.applyLoadedData(safeSet, category, kinds))
+      .catch((error) => this.#onLoadError(safeSet, error))
+      .finally(() => this.finalizeLoad(safeSet));
+  }
+
+  #fetchCategory(slug) {
+    if (!slug) {
+      return Promise.reject(new Error('Unable to load category edit form.'));
+    }
+
+    return this.client.fetch(`/categories/${slug}.json`)
+      .then(this.normalizeCategory.bind(this))
+      .catch(() => { throw new Error('Unable to load category edit form.'); });
+  }
+
+  #fetchKinds() {
+    return this.fetchKinds('Unable to load category edit form.');
+  }
+
+  #onSaveSuccess(saved, fallbackSlug) {
+    const slug = saved?.slug || fallbackSlug;
+    this.locationTarget.hash = `#/categories/${slug}`;
+  }
+
+  #onLoadError(safeSet, error) {
+    safeSet(this.setError, error?.message || 'Unable to load category edit form.');
+  }
+}

--- a/frontend/assets/js/components/pages/controllers/CategoryFormController.js
+++ b/frontend/assets/js/components/pages/controllers/CategoryFormController.js
@@ -1,0 +1,150 @@
+import GenericClient from '../../../client/GenericClient.js';
+import BasePageController from './BasePageController.js';
+
+/**
+ * Shared behavior for category form pages.
+ */
+export default class CategoryFormController extends BasePageController {
+  /**
+   * Creates a new CategoryFormController instance.
+   *
+   * @param {Function} setCategory state setter for category data
+   * @param {Function} setKinds state setter for all available kinds
+   * @param {Function} setLoading state setter for loading status
+   * @param {Function} setSaving state setter for saving status
+   * @param {Function} setError state setter for error message
+   * @param {GenericClient|null} [client] optional client instance
+   * @param {Object|null} [locationTarget] optional location target used for redirects
+   */
+  constructor(setCategory, setKinds, setLoading, setSaving, setError, client = null, locationTarget = null) {
+    super();
+    this.setCategory = setCategory;
+    this.setKinds = setKinds;
+    this.setLoading = setLoading;
+    this.setSaving = setSaving;
+    this.setError = setError;
+    this.client = client ?? new GenericClient();
+    this.locationTarget = locationTarget ?? (typeof window === 'undefined' ? { hash: '' } : window.location);
+  }
+
+  /**
+   * Updates a single field on the current category state.
+   *
+   * @param {string} field field name to update
+   * @param {string} value new field value
+   */
+  onFieldChange(field, value) {
+    this.setCategory((current) => ({ ...current, [field]: value }));
+  }
+
+  /**
+   * Adds a kind to the category kinds list if not already present.
+   *
+   * @param {Object|null} kind kind object with slug and name to add
+   */
+  onAddKind(kind) {
+    if (!kind || !kind.slug) {
+      return;
+    }
+
+    this.setCategory((current) => this.#appendKind(current, kind));
+  }
+
+  /**
+   * Removes the kind with the given slug from the category kinds list.
+   *
+   * @param {string} slug slug of the kind to remove
+   */
+  onRemoveKind(slug) {
+    this.setCategory((current) => ({
+      ...current,
+      kinds: (current.kinds || []).filter((k) => k.slug !== slug),
+    }));
+  }
+
+  /**
+   * Normalizes category fields used by form pages.
+   *
+   * @param {Object} category raw category response
+   * @returns {Object} normalized category object
+   */
+  normalizeCategory(category) {
+    return {
+      ...category,
+      name: category.name || '',
+      kinds: Array.isArray(category.kinds) ? category.kinds : [],
+    };
+  }
+
+  /**
+   * Builds category payload for create and update actions.
+   *
+   * @param {Object} category category state to serialize
+   * @returns {Object} request payload
+   */
+  buildPayload(category) {
+    return {
+      category: {
+        name: category.name || '',
+        kinds: (category.kinds || []).map((k) => ({ slug: k.slug })),
+      },
+    };
+  }
+
+  /**
+   * Fetches available kinds and normalizes response.
+   *
+   * @param {string} loadErrorMessage error message used when request fails
+   * @returns {Promise<Object[]>} kinds list
+   */
+  fetchKinds(loadErrorMessage) {
+    return this.client.fetch('/kinds.json')
+      .then((kinds) => (Array.isArray(kinds) ? kinds : []))
+      .catch(() => { throw new Error(loadErrorMessage); });
+  }
+
+  /**
+   * Applies loaded category and kinds data to state setters.
+   *
+   * @param {Function} safeSet guarded setter helper
+   * @param {Object} category normalized category data
+   * @param {Object[]} kinds kinds list
+   */
+  applyLoadedData(safeSet, category, kinds) {
+    safeSet(this.setCategory, category);
+    safeSet(this.setKinds, kinds);
+  }
+
+  /**
+   * Applies save error message to state.
+   */
+  onSaveError() {
+    this.setError('Unable to save category.');
+  }
+
+  /**
+   * Stops save loading state.
+   */
+  finalizeSave() {
+    this.setSaving(false);
+  }
+
+  /**
+   * Stops page loading state.
+   *
+   * @param {Function} safeSet guarded setter helper
+   */
+  finalizeLoad(safeSet) {
+    safeSet(this.setLoading, false);
+  }
+
+  #appendKind(current, kind) {
+    const kinds = current.kinds || [];
+
+    if (kinds.some((k) => k.slug === kind.slug)) {
+      return current;
+    }
+
+    return { ...current, kinds: [...kinds, kind] };
+  }
+}

--- a/frontend/assets/js/components/pages/controllers/CategoryNewController.js
+++ b/frontend/assets/js/components/pages/controllers/CategoryNewController.js
@@ -1,31 +1,9 @@
-import GenericClient from '../../../client/GenericClient.js';
-import BasePageController from './BasePageController.js';
+import CategoryFormController from './CategoryFormController.js';
 
 /**
  * Manages category new page state and create flow.
  */
-export default class CategoryNewController extends BasePageController {
-  /**
-   * Creates a new CategoryNewController instance.
-   *
-   * @param {Function} setCategory state setter for category data
-   * @param {Function} setKinds state setter for all available kinds
-   * @param {Function} setLoading state setter for loading status
-   * @param {Function} setSaving state setter for saving status
-   * @param {Function} setError state setter for error message
-   * @param {GenericClient|null} [client] optional client instance
-   * @param {Object|null} [locationTarget] optional location target used for redirects
-   */
-  constructor(setCategory, setKinds, setLoading, setSaving, setError, client = null, locationTarget = null) {
-    super();
-    this.setCategory = setCategory;
-    this.setKinds = setKinds;
-    this.setLoading = setLoading;
-    this.setSaving = setSaving;
-    this.setError = setError;
-    this.client = client ?? new GenericClient();
-    this.locationTarget = locationTarget ?? (typeof window === 'undefined' ? { hash: '' } : window.location);
-  }
+export default class CategoryNewController extends CategoryFormController {
 
   /**
    * Builds the React effect that loads new category form data and all kinds on mount.
@@ -60,53 +38,10 @@ export default class CategoryNewController extends BasePageController {
     this.setSaving(true);
     this.setError(null);
 
-    return this.client.post('/categories.json', this.#buildPayload(category))
+    return this.client.post('/categories.json', this.buildPayload(category))
       .then((saved) => this.#onSaveSuccess(saved))
-      .catch(() => this.#onSaveError())
-      .finally(() => this.#finalizeSave());
-  }
-
-  /**
-   * Updates a single field on the current category state.
-   *
-   * @param {string} field field name to update
-   * @param {string} value new field value
-   */
-  onFieldChange(field, value) {
-    this.setCategory((current) => ({ ...current, [field]: value }));
-  }
-
-  /**
-   * Adds a kind to the category kinds list if not already present.
-   *
-   * @param {Object|null} kind kind object with slug and name to add
-   */
-  onAddKind(kind) {
-    if (!kind || !kind.slug) {
-      return;
-    }
-
-    this.setCategory((current) => {
-      const kinds = current.kinds || [];
-
-      if (kinds.some((k) => k.slug === kind.slug)) {
-        return current;
-      }
-
-      return { ...current, kinds: [...kinds, kind] };
-    });
-  }
-
-  /**
-   * Removes the kind with the given slug from the category kinds list.
-   *
-   * @param {string} slug slug of the kind to remove
-   */
-  onRemoveKind(slug) {
-    this.setCategory((current) => ({
-      ...current,
-      kinds: (current.kinds || []).filter((k) => k.slug !== slug),
-    }));
+      .catch(() => this.onSaveError())
+      .finally(() => this.finalizeSave());
   }
 
   /**
@@ -123,43 +58,19 @@ export default class CategoryNewController extends BasePageController {
       this.#fetchCategory(),
       this.#fetchKinds(),
     ])
-      .then(([category, kinds]) => this.#applyLoadedData(safeSet, category, kinds))
+      .then(([category, kinds]) => this.applyLoadedData(safeSet, category, kinds))
       .catch((error) => this.#onLoadError(safeSet, error))
-      .finally(() => this.#finalizeLoad(safeSet));
+      .finally(() => this.finalizeLoad(safeSet));
   }
 
   #fetchCategory() {
     return this.client.fetch('/categories/new.json')
-      .then(CategoryNewController.#normalizeCategory)
+      .then(this.normalizeCategory.bind(this))
       .catch(() => { throw new Error('Unable to load category new form.'); });
   }
 
   #fetchKinds() {
-    return this.client.fetch('/kinds.json')
-      .then((kinds) => (Array.isArray(kinds) ? kinds : []))
-      .catch(() => { throw new Error('Unable to load category new form.'); });
-  }
-
-  static #normalizeCategory(category) {
-    return {
-      ...category,
-      name: category.name || '',
-      kinds: Array.isArray(category.kinds) ? category.kinds : [],
-    };
-  }
-
-  #buildPayload(category) {
-    return {
-      category: {
-        name: category.name || '',
-        kinds: (category.kinds || []).map((k) => ({ slug: k.slug })),
-      },
-    };
-  }
-
-  #applyLoadedData(safeSet, category, kinds) {
-    safeSet(this.setCategory, category);
-    safeSet(this.setKinds, kinds);
+    return this.fetchKinds('Unable to load category new form.');
   }
 
   #onSaveSuccess(saved) {
@@ -167,19 +78,7 @@ export default class CategoryNewController extends BasePageController {
     this.locationTarget.hash = `#/categories/${slug}`;
   }
 
-  #onSaveError() {
-    this.setError('Unable to save category.');
-  }
-
-  #finalizeSave() {
-    this.setSaving(false);
-  }
-
   #onLoadError(safeSet, error) {
     safeSet(this.setError, error?.message || 'Unable to load category new form.');
-  }
-
-  #finalizeLoad(safeSet) {
-    safeSet(this.setLoading, false);
   }
 }

--- a/frontend/assets/js/components/pages/helpers/CategoryHelper.jsx
+++ b/frontend/assets/js/components/pages/helpers/CategoryHelper.jsx
@@ -4,7 +4,6 @@ import CategoryKinds from '../../elements/CategoryKinds.jsx';
 import ErrorContainer from '../../elements/ErrorContainer.jsx';
 import LoadingMessage from '../../elements/LoadingMessage.jsx';
 import OptionalImage from '../../elements/OptionalImage.jsx';
-import PageActionsHelper from './PageActionsHelper.jsx';
 
 /**
  * Renders the category page HTML for different states.
@@ -33,12 +32,13 @@ export default class CategoryHelper {
    * Renders the fully populated category page.
    *
    * @param {Object} category category data
+   * @param {boolean} logged whether the current user is logged in
    * @returns {JSX.Element} category content
    */
-  static render(category) {
+  static render(category, logged) {
     return (
       <div className='container mt-4'>
-        {this.#renderActions(category)}
+        {this.#renderActions(category, logged)}
         <CategoryItemInfoCard name={category.name}>
           <OptionalImage
             src={category.snap_url}
@@ -51,11 +51,29 @@ export default class CategoryHelper {
     );
   }
 
-  static #renderActions(category) {
-    return PageActionsHelper.render(
-      '/#/categories',
-      `/#/categories/${category.slug}/items`,
-      'Items'
+  static #renderActions(category, logged) {
+    return (
+      <div className='mb-3'>
+        <a className='btn btn-outline-secondary me-2' href='/#/categories'>
+          Back
+        </a>
+        <a className='btn btn-primary me-2' href={`/#/categories/${category.slug}/items`}>
+          Items
+        </a>
+        {this.#renderEditAction(category, logged)}
+      </div>
+    );
+  }
+
+  static #renderEditAction(category, logged) {
+    if (!logged) {
+      return null;
+    }
+
+    return (
+      <a className='btn btn-secondary' href={`/#/categories/${category.slug}/edit`}>
+        Edit
+      </a>
     );
   }
 }

--- a/frontend/assets/js/utils/HashRouteResolver.js
+++ b/frontend/assets/js/utils/HashRouteResolver.js
@@ -21,6 +21,7 @@ export default class HashRouteResolver {
     router.register('/categories/:slug/items/new', 'categoryItemNew');
     router.register('/categories/:slug/items/:id', 'categoryItem');
     router.register('/categories/:slug/items', 'categoryItems');
+    router.register('/categories/:slug/edit', 'categoryEdit');
     router.register('/categories/new', 'categoryNew');
     router.register('/categories/:slug', 'category');
     router.register('/categories', 'categories');

--- a/frontend/spec/components/app/AppController_spec.js
+++ b/frontend/spec/components/app/AppController_spec.js
@@ -34,6 +34,12 @@ describe('AppController', function() {
       expect(controller.getPage()).toBe('categoryItems');
     });
 
+    it('returns "categoryEdit" for #/categories/:slug/edit', function() {
+      const controller = new AppController(null, null, () => '#/categories/project/edit');
+
+      expect(controller.getPage()).toBe('categoryEdit');
+    });
+
     it('returns "categories" for #/categories', function() {
       const controller = new AppController(null, null, () => '#/categories');
 

--- a/frontend/spec/components/helpers/AppHelper_spec.js
+++ b/frontend/spec/components/helpers/AppHelper_spec.js
@@ -41,6 +41,12 @@ describe('AppHelper', function() {
       expect(html).toContain('Loading category...');
     });
 
+    it('renders the CategoryEdit component for "categoryEdit" page', function() {
+      const html = renderPage('categoryEdit');
+
+      expect(html).toContain('Loading category new form...');
+    });
+
     it('does not render the home placeholder for "categories" page', function() {
       const html = renderPage('categories');
 

--- a/frontend/spec/components/pages/CategoryEdit_spec.js
+++ b/frontend/spec/components/pages/CategoryEdit_spec.js
@@ -1,0 +1,6 @@
+import CategoryEdit from '../../../assets/js/components/pages/CategoryEdit.jsx';
+import { itRendersPageLoadingState } from '../../support/shared_examples/pageExamples.js';
+
+describe('CategoryEdit', function() {
+  itRendersPageLoadingState(CategoryEdit, 'Loading category new form...');
+});

--- a/frontend/spec/components/pages/controllers/CategoryController_spec.js
+++ b/frontend/spec/components/pages/controllers/CategoryController_spec.js
@@ -18,12 +18,14 @@ describe('CategoryController', function() {
 
   const buildSetters = () => buildSpies(
     'setCategory',
+    'setLogged',
     'setLoading',
     'setError'
   );
 
   beforeEach(function() {
     mockClient = buildMockClient();
+    spyOn(CategoryController.prototype, 'checkLogin').and.returnValue(Promise.resolve(true));
   });
 
   describe('getCategorySlugFromHash', function() {
@@ -47,7 +49,7 @@ describe('CategoryController', function() {
   });
 
   it('fetches category in buildEffect', async function() {
-    const { setCategory, setLoading, setError } = buildSetters();
+    const { setCategory, setLogged, setLoading, setError } = buildSetters();
     const category = {
       slug: 'project',
       name: 'Project',
@@ -59,13 +61,14 @@ describe('CategoryController', function() {
       fetch: jasmine.createSpy('fetch').and.returnValue(Promise.resolve(category)),
     });
 
-    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const controller = new CategoryController(setCategory, setLogged, setLoading, setError, mockClient);
     const cleanup = controller.buildEffect()();
 
     await flushPromises();
 
     expect(mockClient.fetch).toHaveBeenCalledWith('/categories/project.json');
     expect(setCategory).toHaveBeenCalledWith(category);
+    expect(setLogged).toHaveBeenCalledWith(true);
     expect(setLoading).toHaveBeenCalledWith(false);
     expect(setError).not.toHaveBeenCalled();
 
@@ -73,7 +76,7 @@ describe('CategoryController', function() {
   });
 
   it('normalizes missing kinds to an empty array', async function() {
-    const { setCategory, setLoading, setError } = buildSetters();
+    const { setCategory, setLogged, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       fetch: jasmine.createSpy('fetch').and.returnValue(
@@ -81,7 +84,7 @@ describe('CategoryController', function() {
       ),
     });
 
-    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const controller = new CategoryController(setCategory, setLogged, setLoading, setError, mockClient);
     const cleanup = controller.buildEffect()();
 
     await flushPromises();
@@ -94,7 +97,7 @@ describe('CategoryController', function() {
   });
 
   it('calls setError when category fetch fails', async function() {
-    const { setCategory, setLoading, setError } = buildSetters();
+    const { setCategory, setLogged, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       fetch: jasmine.createSpy('fetch').and.returnValue(
@@ -102,7 +105,7 @@ describe('CategoryController', function() {
       ),
     });
 
-    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const controller = new CategoryController(setCategory, setLogged, setLoading, setError, mockClient);
     const cleanup = controller.buildEffect()();
 
     await flushPromises();
@@ -115,13 +118,13 @@ describe('CategoryController', function() {
   });
 
   it('calls setError when params cannot be extracted from hash', async function() {
-    const { setCategory, setLoading, setError } = buildSetters();
+    const { setCategory, setLogged, setLoading, setError } = buildSetters();
 
     mockClient = buildMockClient({
       currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories'),
     });
 
-    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const controller = new CategoryController(setCategory, setLogged, setLoading, setError, mockClient);
     const cleanup = controller.buildEffect()();
 
     await flushPromises();
@@ -134,9 +137,9 @@ describe('CategoryController', function() {
   });
 
   it('does not call setters after unmount', async function() {
-    const { setCategory, setLoading, setError } = buildSetters();
+    const { setCategory, setLogged, setLoading, setError } = buildSetters();
 
-    const controller = new CategoryController(setCategory, setLoading, setError, mockClient);
+    const controller = new CategoryController(setCategory, setLogged, setLoading, setError, mockClient);
     const cleanup = controller.buildEffect()();
 
     cleanup();
@@ -149,9 +152,9 @@ describe('CategoryController', function() {
   });
 
   it('defaults client to a new GenericClient when none is provided', function() {
-    const { setCategory, setLoading, setError } = buildSetters();
+    const { setCategory, setLogged, setLoading, setError } = buildSetters();
 
-    const controller = new CategoryController(setCategory, setLoading, setError);
+    const controller = new CategoryController(setCategory, setLogged, setLoading, setError);
 
     expect(controller.client).toBeInstanceOf(GenericClient);
   });

--- a/frontend/spec/components/pages/controllers/CategoryEditController_spec.js
+++ b/frontend/spec/components/pages/controllers/CategoryEditController_spec.js
@@ -1,0 +1,174 @@
+import CategoryEditController, { getCategoryEditSlugFromHash } from '../../../../assets/js/components/pages/controllers/CategoryEditController.js';
+import GenericClient from '../../../../assets/js/client/GenericClient.js';
+import {
+  buildSpies,
+  flushPromises,
+} from '../../../support/factories.js';
+
+describe('CategoryEditController', function() {
+  let mockClient;
+  let mockLocation;
+
+  const buildMockClient = (overrides = {}) => ({
+    currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/project/edit'),
+    fetch: jasmine.createSpy('fetch').and.callFake((path) => {
+      if (path === '/categories/project.json') {
+        return Promise.resolve({
+          slug: 'project',
+          name: 'Project',
+          kinds: [{ slug: 'code', name: 'Code' }],
+        });
+      }
+
+      if (path === '/kinds.json') {
+        return Promise.resolve([
+          { slug: 'code', name: 'Code' },
+          { slug: 'hardware', name: 'Hardware' },
+        ]);
+      }
+
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    }),
+    patch: jasmine.createSpy('patch').and.returnValue(Promise.resolve({ slug: 'project-edited' })),
+    ...overrides,
+  });
+
+  const buildSetters = () => buildSpies(
+    'setCategory',
+    'setKinds',
+    'setLoading',
+    'setSaving',
+    'setError'
+  );
+
+  const buildController = (setters, client = null, location = null) => {
+    const { setCategory, setKinds, setLoading, setSaving, setError } = setters;
+
+    return new CategoryEditController(
+      setCategory,
+      setKinds,
+      setLoading,
+      setSaving,
+      setError,
+      client ?? mockClient,
+      location ?? mockLocation
+    );
+  };
+
+  beforeEach(function() {
+    mockClient = buildMockClient();
+    mockLocation = { hash: '#/categories/project/edit' };
+  });
+
+  describe('getCategoryEditSlugFromHash', function() {
+    it('extracts category slug from edit hash route', function() {
+      expect(getCategoryEditSlugFromHash('#/categories/project/edit?page=2')).toBe('project');
+    });
+
+    it('returns empty slug when hash does not match the edit route', function() {
+      expect(getCategoryEditSlugFromHash('#/categories/project')).toBe('');
+    });
+  });
+
+  it('loads category form and kinds in buildEffect', async function() {
+    const setters = buildSetters();
+    const cleanup = buildController(setters).buildEffect()();
+
+    await flushPromises();
+
+    expect(mockClient.fetch).toHaveBeenCalledWith('/categories/project.json');
+    expect(mockClient.fetch).toHaveBeenCalledWith('/kinds.json');
+    expect(setters.setCategory).toHaveBeenCalledWith({
+      slug: 'project',
+      name: 'Project',
+      kinds: [{ slug: 'code', name: 'Code' }],
+    });
+    expect(setters.setKinds).toHaveBeenCalledWith([
+      { slug: 'code', name: 'Code' },
+      { slug: 'hardware', name: 'Hardware' },
+    ]);
+    expect(setters.setLoading).toHaveBeenCalledWith(false);
+    expect(setters.setError).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('sets error when loading fails', async function() {
+    mockClient = buildMockClient({
+      fetch: jasmine.createSpy('fetch').and.returnValue(Promise.reject(new Error('boom'))),
+    });
+    const setters = buildSetters();
+    const cleanup = buildController(setters).buildEffect()();
+
+    await flushPromises();
+
+    expect(setters.setError).toHaveBeenCalledWith('Unable to load category edit form.');
+    expect(setters.setLoading).toHaveBeenCalledWith(false);
+
+    cleanup();
+  });
+
+  it('patches payload and redirects to category page on save', async function() {
+    const setters = buildSetters();
+
+    await buildController(setters).save({
+      name: 'Project Edited',
+      kinds: [{ slug: 'code', name: 'Code' }],
+    });
+
+    expect(mockClient.patch).toHaveBeenCalledWith('/categories/project', {
+      category: {
+        name: 'Project Edited',
+        kinds: [{ slug: 'code' }],
+      },
+    });
+    expect(mockLocation.hash).toBe('#/categories/project-edited');
+    expect(setters.setSaving).toHaveBeenCalledWith(true);
+    expect(setters.setSaving).toHaveBeenCalledWith(false);
+    expect(setters.setError).toHaveBeenCalledWith(null);
+  });
+
+  it('uses current slug when save response has no slug', async function() {
+    mockClient = buildMockClient({
+      patch: jasmine.createSpy('patch').and.returnValue(Promise.resolve({})),
+    });
+    const setters = buildSetters();
+
+    await buildController(setters).save({ name: 'Project Edited', kinds: [] });
+
+    expect(mockLocation.hash).toBe('#/categories/project');
+  });
+
+  it('sets error when save fails', async function() {
+    mockClient = buildMockClient({
+      patch: jasmine.createSpy('patch').and.returnValue(Promise.reject(new Error('boom'))),
+    });
+    const setters = buildSetters();
+
+    await buildController(setters).save({ name: 'Project Edited', kinds: [] });
+
+    expect(setters.setError).toHaveBeenCalledWith('Unable to save category.');
+    expect(setters.setSaving).toHaveBeenCalledWith(false);
+  });
+
+  it('rejects and sets error when slug is missing on save', async function() {
+    mockClient = buildMockClient({
+      currentHash: jasmine.createSpy('currentHash').and.returnValue('#/categories/new'),
+    });
+    const setters = buildSetters();
+    let caught = false;
+
+    await buildController(setters).save({ name: 'Project Edited', kinds: [] }).catch(() => { caught = true; });
+
+    expect(caught).toBe(true);
+    expect(setters.setError).toHaveBeenCalledWith('Unable to save category.');
+    expect(mockClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('defaults client to a new GenericClient when none is provided', function() {
+    const { setCategory, setKinds, setLoading, setSaving, setError } = buildSetters();
+    const controller = new CategoryEditController(setCategory, setKinds, setLoading, setSaving, setError);
+
+    expect(controller.client).toBeInstanceOf(GenericClient);
+  });
+});

--- a/frontend/spec/components/pages/helpers/CategoryHelper_spec.js
+++ b/frontend/spec/components/pages/helpers/CategoryHelper_spec.js
@@ -16,18 +16,26 @@ describe('CategoryHelper', function() {
   itRendersLoadingAndErrorStates(CategoryHelper, 'Loading category...');
 
   it('renders actions and category data', function() {
-    const html = renderStatic(CategoryHelper.render(category));
+    const html = renderStatic(CategoryHelper.render(category, false));
 
     expect(html).toContain('/#/categories');
     expect(html).toContain('/#/categories/project/items');
+    expect(html).not.toContain('/#/categories/project/edit');
     expect(html).toContain('Back');
     expect(html).toContain('Items');
     expect(html).toContain('Project');
     expect(html).toContain('http://example.com/project.png');
   });
 
+  it('renders edit action when user is logged in', function() {
+    const html = renderStatic(CategoryHelper.render(category, true));
+
+    expect(html).toContain('/#/categories/project/edit');
+    expect(html).toContain('Edit');
+  });
+
   it('renders connected kinds as badges', function() {
-    const html = renderStatic(CategoryHelper.render(category));
+    const html = renderStatic(CategoryHelper.render(category, false));
 
     expect(html).toContain('Kinds');
     expect(html).toContain('Code');
@@ -36,7 +44,7 @@ describe('CategoryHelper', function() {
   });
 
   it('renders empty kinds message when category has no kinds', function() {
-    const html = renderStatic(CategoryHelper.render({ ...category, kinds: [] }));
+    const html = renderStatic(CategoryHelper.render({ ...category, kinds: [] }, false));
 
     expect(html).toContain('No kinds connected.');
   });

--- a/frontend/spec/utils/HashRouteResolver_spec.js
+++ b/frontend/spec/utils/HashRouteResolver_spec.js
@@ -58,6 +58,12 @@ describe('HashRouteResolver', function() {
       expect(resolver.getPage()).toBe('categoryNew');
     });
 
+    it('returns "categoryEdit" for category edit routes', function() {
+      const resolver = new HashRouteResolver(() => '#/categories/project/edit');
+
+      expect(resolver.getPage()).toBe('categoryEdit');
+    });
+
     it('returns "category" for category routes', function() {
       const resolver = new HashRouteResolver(() => '#/categories/project?page=2&per_page=10');
 


### PR DESCRIPTION
Implements category editing in the new SPA frontend at `/#/categories/:slug/edit`, mirroring the existing new/edit pattern used by items. The flow now loads category data by slug, submits updates via `PATCH /categories/:slug`, and returns to the category show page after save.

- **Routing + page wiring**
  - Added hash route resolution for `/#/categories/:slug/edit` (`categoryEdit` page key).
  - Registered `CategoryEdit` in app page mapping.

- **Category edit flow (reusing category form UI)**
  - Added `CategoryEdit` page component that reuses `CategoryNewHelper` form rendering.
  - Added `CategoryEditController` to:
    - parse slug from edit route,
    - load `GET /categories/:slug.json` + `GET /kinds.json`,
    - submit `PATCH /categories/:slug` with editable fields (`name`, `kinds`),
    - redirect to `/#/categories/:slug` (prefers response slug, falls back to route slug).

- **Show page edit affordance**
  - Extended category show flow to include login state.
  - Added an **Edit** action on `/#/categories/:slug`, visible only when logged in.
  - Kept existing Back/Items actions unchanged.

- **Spec coverage updates**
  - Added/updated specs for:
    - hash route and app page resolution for `categoryEdit`,
    - category edit controller data loading + PATCH save/redirect behavior,
    - category page helper conditional edit-link visibility for logged users,
    - category controller login-state integration.

```js
// CategoryEditController save flow
return this.client.patch(`/categories/${slug}`, {
  category: {
    name: category.name || '',
    kinds: (category.kinds || []).map((k) => ({ slug: k.slug })),
  },
}).then((saved) => {
  this.locationTarget.hash = `#/categories/${saved?.slug || slug}`;
});
```

Fixes #185 